### PR TITLE
make search textbox case-insensitive

### DIFF
--- a/Chocolatey Explorer/View/PackageManager.cs
+++ b/Chocolatey Explorer/View/PackageManager.cs
@@ -332,7 +332,7 @@ namespace Chocolatey.Explorer.View
         {
             DataGridViewRow rowFound = PackageGrid.Rows.OfType<DataGridViewRow>()
                     .FirstOrDefault(row => row.Cells.OfType<DataGridViewCell>()
-                    .Any(cell => cell.ColumnIndex == 0 && ((String)cell.Value).StartsWith(SearchPackages.Text)));
+                    .Any(cell => cell.ColumnIndex == 0 && ((String)cell.Value).StartsWith(SearchPackages.Text, StringComparison.OrdinalIgnoreCase)));
 
             if (rowFound != null)
             {


### PR DESCRIPTION
I was looking to install the Secunia.PSI package, and was surprised that typing 'secu' didn't find it.  IMHO this should potentially be a substring search instead of startswith, but I'm just changing it to case-insensitive here. :)
