### PR TITLE
Fixed Version Regex.

### DIFF
--- a/Chocolatey.Explorer/Services/ChocolateyLibDirHelper.cs
+++ b/Chocolatey.Explorer/Services/ChocolateyLibDirHelper.cs
@@ -69,7 +69,7 @@ namespace Chocolatey.Explorer.Services
             // Version: '0.9.8.21-alpha3'
             // The most typical is the four version numbers, but to account for the format string used by
             // Chocolatey itself, the additional optionals were added to the regular expression
-            var match = Regex.Match(version, "Version:[ ]+'([0-9\\.]+)-[a-z]{0,5}?[0-9]?'");
+            var match = Regex.Match(version, @"Version:\s+'([0-9\\.]+)(?:-[a-z]{1,5}?\d?)?'");
 
             if (!match.Success)
             {


### PR DESCRIPTION
Fix #78 (3 weeks ago) fixed the regex for the version string used by Chocolatey at that time (which had an alpha suffix) but broke it with the latest version (from two days ago) which has no suffix.  This regex pattern will handle both styles.
