### PR TITLE
Updating .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,12 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 
+# =========================
+# Custom Additions
+# =========================
+
+# Where everything from the build is put
 BuildArtifacts
+
+# Temporary files that kdiff generates
+*.orig


### PR DESCRIPTION
- Added additional check to prevent *.orig files, which are generated by kdiff when doing a merge, being checked into source control
