### PR TITLE
(GH-253) Include chocolatey's global sources in the source list

### DIFF
--- a/Source/ChocolateyGui/Providers/ChocolateyConfigurationProvider.cs
+++ b/Source/ChocolateyGui/Providers/ChocolateyConfigurationProvider.cs
@@ -7,65 +7,80 @@
 namespace ChocolateyGui.Providers
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Xml.Linq;
 
     public class ChocolateyConfigurationProvider : IChocolateyConfigurationProvider
     {
-        private string _chocolateyInstallLocation;
-        private bool _isChocolateyExecutableBeingUsed;
+        private readonly Lazy<string> _chocolateyInstallLocation;
+        private readonly Lazy<bool> _isChocolateyExecutableBeingUsed;
 
         public ChocolateyConfigurationProvider()
         {
-            this.GetChocolateyInstallLocation();
-            this.DetermineIfChocolateyExecutableIsBeingUsed();
+            this._chocolateyInstallLocation = new Lazy<string>(this.GetChocolateyInstallLocation);
+            this._isChocolateyExecutableBeingUsed = new Lazy<bool>(this.DetermineIfChocolateyExecutableIsBeingUsed);
         }
 
         public string ChocolateyInstall
         {
-            get
-            {
-                return this._chocolateyInstallLocation;
-            }
+            get { return this._chocolateyInstallLocation.Value; }
         }
 
         public bool IsChocolateyExecutableBeingUsed
         {
-            get
-            {
-                return this._isChocolateyExecutableBeingUsed;
-            }
+            get { return this._isChocolateyExecutableBeingUsed.Value; }
         }
 
-        private void GetChocolateyInstallLocation()
+        public IEnumerable<Tuple<string, string>> Sources
         {
-            this._chocolateyInstallLocation = Environment.GetEnvironmentVariable("ChocolateyInstall");
-            if (string.IsNullOrWhiteSpace(this._chocolateyInstallLocation))
+            get { return this.GetChocolateySources(); }
+        }
+
+        private string GetChocolateyInstallLocation()
+        {
+            var retVal = Environment.GetEnvironmentVariable("ChocolateyInstall");
+            if (string.IsNullOrWhiteSpace(retVal))
             {
                 var pathVar = Environment.GetEnvironmentVariable("PATH");
                 if (!string.IsNullOrWhiteSpace(pathVar))
                 {
-                    this._chocolateyInstallLocation =
+                    retVal =
                         pathVar.Split(';')
                             .SingleOrDefault(
                                 path => path.IndexOf("Chocolatey", StringComparison.OrdinalIgnoreCase) > -1);
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(this._chocolateyInstallLocation))
+            if (string.IsNullOrWhiteSpace(retVal))
             {
-                this._chocolateyInstallLocation = string.Empty;
+                retVal = string.Empty;
             }
+
+            return retVal;
         }
 
-        private void DetermineIfChocolateyExecutableIsBeingUsed()
+        private bool DetermineIfChocolateyExecutableIsBeingUsed()
         {
-            var exePath = Path.Combine(this._chocolateyInstallLocation, "choco.exe");
+            var exePath = Path.Combine(this._chocolateyInstallLocation.Value, "choco.exe");
 
-            if (File.Exists(exePath))
+            return File.Exists(exePath);
+        }
+
+        private IEnumerable<Tuple<string, string>> GetChocolateySources()
+        {
+            var chocoConfigFile = Path.Combine(this._chocolateyInstallLocation.Value, "config", "chocolatey.config");
+
+            if (File.Exists(chocoConfigFile))
             {
-                this._isChocolateyExecutableBeingUsed = true;
+                var configDoc = XDocument.Load(chocoConfigFile);
+
+                return configDoc.Descendants("source")
+                    .Select(e => Tuple.Create(e.Attribute("id").Value, e.Attribute("value").Value));
             }
+
+            return Enumerable.Empty<Tuple<string, string>>();
         }
     }
 }

--- a/Source/ChocolateyGui/Providers/IChocolateyConfigurationProvider.cs
+++ b/Source/ChocolateyGui/Providers/IChocolateyConfigurationProvider.cs
@@ -6,10 +6,15 @@
 
 namespace ChocolateyGui.Providers
 {
+    using System;
+    using System.Collections.Generic;
+
     public interface IChocolateyConfigurationProvider
     {
         string ChocolateyInstall { get; }
 
         bool IsChocolateyExecutableBeingUsed { get; }
+
+        IEnumerable<Tuple<string, string>> Sources { get; }
     }
 }

--- a/Source/ChocolateyGui/Services/SettingsSourceService.cs
+++ b/Source/ChocolateyGui/Services/SettingsSourceService.cs
@@ -94,11 +94,16 @@ namespace ChocolateyGui.Services
 
             public int GetHashCode(Tuple<string, string> obj)
             {
+                if (object.ReferenceEquals(obj, null))
+                {
+                    throw new ArgumentNullException("obj");
+                }
+
                 // URIs are functionally equivalent with or without trailing slashes.
                 var url = obj.Item2.TrimEnd('/', '\\');
 
                 return unchecked(obj.Item1.ToUpperInvariant().GetHashCode() // Name
-                    + url.GetHashCode());                                   
+                    + url.GetHashCode());
             }
         }
     }

--- a/Source/ChocolateyGui/Services/SettingsSourceService.cs
+++ b/Source/ChocolateyGui/Services/SettingsSourceService.cs
@@ -12,10 +12,18 @@ namespace ChocolateyGui.Services
     using System.Linq;
     using ChocolateyGui.Models;
     using ChocolateyGui.Properties;
+    using ChocolateyGui.Providers;
     using ChocolateyGui.ViewModels.Items;
 
     internal class SettingsSourceService : ISourceService
     {
+        private readonly IChocolateyConfigurationProvider _chocoConfig;
+
+        public SettingsSourceService(IChocolateyConfigurationProvider chocoConfig)
+        {
+            this._chocoConfig = chocoConfig;
+        }
+
         public event SourcesChangedEventHandler SourcesChanged;
 
         public void AddSource(SourceViewModel sourceViewModel)
@@ -51,8 +59,11 @@ namespace ChocolateyGui.Services
         public IEnumerable<SourceViewModel> GetSources()
         {
             var sources = Settings.Default.sources;
-            return (from string source in sources select source.Split('|'))
-                .Select(parts => new SourceViewModel { Name = parts[0], Url = parts[1] });
+            var sourcesAsTuples = (from string source in sources select source.Split('|'))
+                .Select(s => Tuple.Create(s[0], s[1]));
+
+            return sourcesAsTuples.Union(this._chocoConfig.Sources, new SourceTupleComparer())
+                .Select(parts => new SourceViewModel { Name = parts.Item1, Url = parts.Item2 });
         }
 
         public void RemoveSource(SourceViewModel viewModel)
@@ -72,6 +83,23 @@ namespace ChocolateyGui.Services
             }
 
             Settings.Default.Save();
+        }
+
+        internal class SourceTupleComparer : IEqualityComparer<Tuple<string, string>>
+        {
+            public bool Equals(Tuple<string, string> x, Tuple<string, string> y)
+            {
+                return this.GetHashCode(x) == this.GetHashCode(y);
+            }
+
+            public int GetHashCode(Tuple<string, string> obj)
+            {
+                // URIs are functionally equivalent with or without trailing slashes.
+                var url = obj.Item2.TrimEnd('/', '\\');
+
+                return unchecked(obj.Item1.ToUpperInvariant().GetHashCode() // Name
+                    + url.GetHashCode());                                   
+            }
         }
     }
 }


### PR DESCRIPTION
Takes chocolatey's global sources list, unions with the app-specific source list. Filters out any name|uri matches.

Also modified the determination of Choco Install location & Executable usage to be `Lazy<T>`

Note: This is an interface change to `IChocolateyConfigurationProvider`