### PR TITLE
GH-2665 Allowed you to search based on both only those with updates a…

### DIFF
--- a/Source/ChocolateyGui/ViewModels/Controls/LocalSourceControlViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Controls/LocalSourceControlViewModel.cs
@@ -247,32 +247,39 @@ namespace ChocolateyGui.ViewModels.Controls
         private void FilterPackages()
         {
             this.Packages.Clear();
+
+            IEnumerable<IPackageViewModel> query = this._packages;
+
             if (!string.IsNullOrWhiteSpace(this.SearchQuery))
             {
-                var query = this.MatchWord
-                     ? this._packages.Where(
+                query = this.MatchWord
+                     ? query.Where(
                          package =>
                          string.Compare(
                              package.Title ?? package.Id,
                              this.SearchQuery,
                              StringComparison.OrdinalIgnoreCase) == 0)
-                                : this._packages.Where(
+                                : query.Where(
                          package =>
                          CultureInfo.CurrentCulture.CompareInfo.IndexOf(
                              package.Title ?? package.Id,
                              this.SearchQuery,
                              CompareOptions.OrdinalIgnoreCase) >= 0);
-
-                query.ToList().ForEach(this.Packages.Add);
             }
-            else if (this.ShowOnlyPackagesWithUpdate)
+
+            if (this.ShowOnlyPackagesWithUpdate)
             {
-                var query = this._packages.Where(p => p.CanUpdate == true);
-                query.ToList().ForEach(this.Packages.Add);
+                query = query.Where(p => p.CanUpdate);
+            }
+
+            if (object.ReferenceEquals(query, this._packages))
+            {
+                // If we haven't done any filtering don't bother to add each package to the observable collection individually 
+                this.Packages = new ObservableCollection<IPackageViewModel>(this._packages);
             }
             else
             {
-                this.Packages = new ObservableCollection<IPackageViewModel>(this._packages);
+                query.ToList().ForEach(this.Packages.Add);
             }
         }
 


### PR DESCRIPTION
…nd query

Previously when there was a query and the Search for only those with
updates box was checked the packages were only filtered by the search
query now they are filtered by both,

This fixes issue https://github.com/chocolatey/ChocolateyGUI/issues/265