### PR TITLE
(GH-285) Add Control Margins

### DIFF
--- a/Source/ChocolateyGui/Views/Controls/LocalSourceControl.xaml
+++ b/Source/ChocolateyGui/Views/Controls/LocalSourceControl.xaml
@@ -25,9 +25,9 @@
             <CheckBox Name="UpdatesCheckBox" Margin="5" Content="Show Only Packages with Updates" IsChecked="{Binding ShowOnlyPackagesWithUpdate}"/>
         </StackPanel>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,5">
-            <Button Command="{commands:DataContextCommandAdapter RefreshPackages, CanRefreshPackages}" Style="{StaticResource SquareButtonStyle}" Content="Refresh Packages"></Button>
-            <Button Command="{commands:DataContextCommandAdapter UpdateAll, CanUpdateAll}" Visibility="{Binding ShowOnlyPackagesWithUpdate, Converter={StaticResource BoolToVis}}" Style="{StaticResource SquareButtonStyle}" Content="Update All"/>
-            <Button Command="{commands:DataContextCommandAdapter ExportAll, CanExportAll}" Style="{StaticResource SquareButtonStyle}" Content="Export"/>
+            <Button Command="{commands:DataContextCommandAdapter RefreshPackages, CanRefreshPackages}" Style="{StaticResource SquareButtonStyle}" Content="Refresh Packages" Margin="4,0,4,0"></Button>
+            <Button Command="{commands:DataContextCommandAdapter UpdateAll, CanUpdateAll}" Visibility="{Binding ShowOnlyPackagesWithUpdate, Converter={StaticResource BoolToVis}}" Style="{StaticResource SquareButtonStyle}" Margin="4,0,4,0"  Content="Update All"/>
+            <Button Command="{commands:DataContextCommandAdapter ExportAll, CanExportAll}" Style="{StaticResource SquareButtonStyle}" Margin="4,0,0,0"  Content="Export"/>
         </StackPanel>
         <DataGrid Grid.Row="1" ItemsSource="{Binding Packages}" Background="{StaticResource LightBackgroundColorBrush}"
                   AutoGenerateColumns="False" IsReadOnly="True"

--- a/Source/ChocolateyGui/Views/Controls/RemoteSourceControl.xaml
+++ b/Source/ChocolateyGui/Views/Controls/RemoteSourceControl.xaml
@@ -31,7 +31,7 @@
             <CheckBox Name="MatchCheckBox" Margin="5" Content="Match Word Exactly" IsChecked="{Binding MatchWord}"/>
         </StackPanel>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,5">
-            <Button Command="{commands:DataContextCommandAdapter RefreshRemotePackages, CanRefreshRemotePackages}" Style="{StaticResource SquareButtonStyle}" Content="Refresh Packages"></Button>
+            <Button Command="{commands:DataContextCommandAdapter RefreshRemotePackages, CanRefreshRemotePackages}" Style="{StaticResource SquareButtonStyle}" Content="Refresh Packages" Margin="0,4,0,4"></Button>
         </StackPanel>
 
         <Grid Grid.Row="2" DockPanel.Dock="Bottom" Margin="4">

--- a/Source/ChocolateyGui/Views/Windows/MainWindow.xaml
+++ b/Source/ChocolateyGui/Views/Windows/MainWindow.xaml
@@ -81,18 +81,18 @@
 				<StackPanel Margin="10,0">
 					<DataGrid x:Name="SourcesDataGrid" AutoGenerateColumns="False"
 							  ItemsSource="{Binding Sources}" IsReadOnly="True"
-							  SelectedItem="{Binding SelectedSource}">
+							  SelectedItem="{Binding SelectedSource}" Margin="4">
 						<DataGrid.Columns>
 							<DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="1*"/>
 							<DataGridTextColumn Header="Url" Binding="{Binding Url}" Width="1*"/>
 						</DataGrid.Columns>
 					</DataGrid>
-					<Button Command="{commands:DataContextCommandAdapter RemoveSource, CanRemoveSource}">Remove Source</Button>
-					<TextBlock Margin="0,10,0,0">Name:</TextBlock>
-					<TextBox Text="{Binding NewSourceName, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-					<TextBlock>Url:</TextBlock>
-					<TextBox Text="{Binding NewSourceUrl, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-					<Button Command="{commands:DataContextCommandAdapter AddSource, CanAddSource}">Add Source</Button>
+					<Button Command="{commands:DataContextCommandAdapter RemoveSource, CanRemoveSource}" Margin="4">Remove Source</Button>
+					<TextBlock Margin="4,10,0,0">Name:</TextBlock>
+					<TextBox Text="{Binding NewSourceName, UpdateSourceTrigger=PropertyChanged}" Margin="4"></TextBox>
+					<TextBlock Margin="4,0,0,0">Url:</TextBlock>
+					<TextBox Text="{Binding NewSourceUrl, UpdateSourceTrigger=PropertyChanged}" Margin="4"></TextBox>
+					<Button Command="{commands:DataContextCommandAdapter AddSource, CanAddSource}" Margin="4">Add Source</Button>
 				</StackPanel>
 			</metro:Flyout>
 		</metro:FlyoutsControl>


### PR DESCRIPTION
I used a four-pixel margin to the controls, as I thought that looked good. In addition, I adjusted some of the thicknesses of the margins to not add extra padding where there already was some applied from the parent control. (This is why you see `Thickness="0,4,0,4"` in the below diff.) If you disagree on the amount of padding applied, please comment and I will revise my PR.