### PR TITLE
(GH-290) Fix for package details are not loaded correctly (#290)

### DIFF
--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -411,9 +411,8 @@ namespace ChocolateyGui.ViewModels.Items
 
         public async void ViewDetails()
         {
-            var item = this as IPackageViewModel;
-            await item.EnsureIsLoaded();
-            this._navigationService.Navigate(typeof(PackageControl), item);
+            await this.EnsureIsLoaded();
+            this._navigationService.Navigate(typeof(PackageControl), this);
         }
 
         private string MemoryCachePropertyKey([CallerMemberName] string propertyName = "")

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -409,9 +409,11 @@ namespace ChocolateyGui.ViewModels.Items
             }
         }
 
-        public void ViewDetails()
+        public async void ViewDetails()
         {
-            this._navigationService.Navigate(typeof(PackageControl), this);
+            var item = this as IPackageViewModel;
+            await item.EnsureIsLoaded();
+            this._navigationService.Navigate(typeof(PackageControl), item);
         }
 
         private string MemoryCachePropertyKey([CallerMemberName] string propertyName = "")


### PR DESCRIPTION
The package details (like created, last updated etc.) are not loaded if you select an package, right-click on it and select "Details". This commit will fix this with ensuring the item is loaded correctly.