### PR TITLE
Crash on startup

### DIFF
--- a/Source/ChocolateyGui/Services/BasePackageService.cs
+++ b/Source/ChocolateyGui/Services/BasePackageService.cs
@@ -284,7 +284,7 @@ namespace ChocolateyGui.Services
 
             var packageConfigEntry =
                 this.PackageConfigEntries()
-                    .SingleOrDefault(
+                    .FirstOrDefault(
                         entry =>
                         string.Compare(entry.Id, packageInfo.Id, StringComparison.OrdinalIgnoreCase) == 0
                         && entry.Version == packageInfo.Version);


### PR DESCRIPTION
Fix for a crash when starting ChocolateyGUI, when multiple entries exist in packages.json, which only differ in case.
Please find below the packages.json file that was causing the crash.
I have no idea how the file became in this state (I didn't tamper with it).

>>> START OF packages.json

[
  {
    "Id": "git",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "2.5.3"
  },
  {
    "Id": "git.install",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "2.5.3"
  },
  {
    "Id": "linkshellextension",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "3.8.6.2"
  },
  {
    "Id": "notepadplusplus.install",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "6.8.3"
  },
  {
    "Id": "chocolatey",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "0.9.9.11"
  },
  {
    "Id": "LinkShellExtension",
    "Source": "https:\/\/chocolatey.org\/api\/v2",
    "Version": "3.8.6.2"
  }
]