### PR TITLE
(GH-288) Filter packages list after refreshing or updating all packages.

### DIFF
--- a/Source/ChocolateyGui/ViewModels/Controls/LocalSourceControlViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Controls/LocalSourceControlViewModel.cs
@@ -182,6 +182,7 @@ namespace ChocolateyGui.ViewModels.Controls
                     if (token.IsCancellationRequested)
                     {
                         await this._progressService.StopLoading();
+                        this.RefreshPackages();
                         return;
                     }
 
@@ -190,7 +191,6 @@ namespace ChocolateyGui.ViewModels.Controls
                 }
 
                 await this._progressService.StopLoading();
-                this.ShowOnlyPackagesWithUpdate = false;
                 this.RefreshPackages();
             }
             catch (Exception ex)
@@ -245,6 +245,7 @@ namespace ChocolateyGui.ViewModels.Controls
         public async void RefreshPackages()
         {
             await this.LoadPackages();
+            this.FilterPackages();
         }
 
         private void FilterPackages()


### PR DESCRIPTION
What this change do:
1. After finishing "Update all" the packages are reloaded and are filtered.
2. After "Update all" was cancelled the list is reloaded and filtered.
3. After "Refresh packages" the list is filtered.

Hope it knocks out all possibilities we have there.