### PR TITLE
(GH-331) missing packages in ChocolateyGUI

### DIFF
--- a/Source/ChocolateyGui/ViewModels/Controls/RemoteSourceControlViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Controls/RemoteSourceControlViewModel.cs
@@ -204,7 +204,7 @@ namespace ChocolateyGui.ViewModels.Controls
             var result = await _remotePackageService.Search(SearchQuery, new PackageSearchOptions(PageSize, CurrentPage - 1, SortColumn, IncludePrerelease, IncludeAllVersions, MatchWord));
             var installed = await _chocolateyPackageService.GetInstalledPackages();
 
-            PageCount = result.TotalCount / PageSize;
+            PageCount = (int)(((double)result.TotalCount / (double)PageSize) + 0.5);
             Packages.Clear();
             result.Packages.ToList().ForEach(p =>
             {


### PR DESCRIPTION
The calculation of needed pages (PageCount) was wrong because of an invalid integer calculation where a floating-point operation would be needed.

Without this change there might be not enought pages to display all packages.
Example: 60 packages in repo - only 1 page containing 50 packages would be visible