### PR TITLE
(GH-337) FauxPowerShellConsole: OrangeRed as 'Warning' very misleading

### DIFF
--- a/Source/ChocolateyGui/Controls/FauxPowerShellConsole.cs
+++ b/Source/ChocolateyGui/Controls/FauxPowerShellConsole.cs
@@ -158,7 +158,7 @@ namespace ChocolateyGui.Controls
                 case PowerShellLineType.Verbose:
                     return new Tuple<Brush, Brush>(Brushes.Gray, Brushes.Transparent);
                 case PowerShellLineType.Warning:
-                    return new Tuple<Brush, Brush>(Brushes.OrangeRed, Brushes.Black);
+                    return new Tuple<Brush, Brush>(Brushes.Yellow, Brushes.Black);
                 case PowerShellLineType.Error:
                     return new Tuple<Brush, Brush>(Brushes.Red, Brushes.Black);
                 default:


### PR DESCRIPTION
switched warning color from OrangeRed to Yellow