### PR TITLE
Update to be compliant with core team guidelines

### DIFF
--- a/nuspec/chocolatey/ChocolateyGUI.nuspec
+++ b/nuspec/chocolatey/ChocolateyGUI.nuspec
@@ -1,29 +1,37 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>ChocolateyGUI</id>
+    <id>chocolateygui</id>
     <version>$version$</version>
     <title>ChocolateyGUI</title>
     <authors>Chocolatey</authors>
     <owners>Chocolatey</owners>
-	  <iconUrl>https://github.com/chocolatey/chocolatey/raw/master/docs/logo/chocolateyicon.gif</iconUrl>
-    <licenseUrl>https://raw.githubusercontent.com/chocolatey/ChocolateyGUI/develop/LICENSE</licenseUrl>
     <projectUrl>https://github.com/chocolatey/ChocolateyGUI</projectUrl>
+    <projectSourceUrl>https://github.com/chocolatey/ChocolateyGUI</projectSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey/ChocolateyGUI/tree/develop/ChocolateyPackage</packageSourceUrl>
+	  <iconUrl>https://cdn.rawgit.com/chocolatey/choco/8b6217061a4efe6543622e903996bb8eac012db2/docs/images/Choco_Icon.png</iconUrl>
+    <licenseUrl>https://raw.githubusercontent.com/chocolatey/ChocolateyGUI/develop/LICENSE</licenseUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/ChocolateyGUI/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>
-ChocolateyGUI is a nice GUI on top of the Chocolatey command line tool. 
-It let's you install, upgrade and uninstall packages.
-It shows you the available packages and it shows the installed packages.
-It shows all the information about a package.
+    <description>    
+ChocolateyGUI is a nice GUI on top of the Chocolatey command line tool.
 
-This package will only work correctly on Windows 7 SP1, Windows Server 2008 R2 SP1 and Windows 
-Server 2008 SP2 and above, and requires .Net Fx 4.5.2 at minimum.
+## Features
+
+* View all **installed** and **available** packages
+* **Update** installed but outdated packages
+* **Install** and **uninstall** packages
+* See detailed **package information**
+
+## Notes
+This package will only work correctly on Windows 7 SP1, Windows Server 2008 R2 SP1,
+Windows Server 2008 SP2 and above, and requires .NET Framework 4.5.2 at minimum.
 	</description>
     <summary>A GUI for Chocolatey</summary>
 	<releaseNotes>
 All release notes for ChocolateyGUI can be found on the GitHub site - https://github.com/chocolatey/ChocolateyGUI/releases
 	</releaseNotes>
-    <tags>ChocolateyGUI chocolatey admin</tags>
+    <tags>chocolateygui chocolatey admin foss</tags>
     <dependencies>
       <dependency id="Chocolatey" version="[0.10.3, 0.11)" />
     </dependencies>	


### PR DESCRIPTION
Update nuspec to be more compatible with [Core Team Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Contributing-guidelines):
* Update Icon to new logo and use commit hash
* Add `projectSourceUrl`
* Add `packageSourceUrl`
* Add `bugTrackerUrl`
* Update description as per [Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Contributing-guidelines#123-informative-description)
* Add `foss` tag as per [Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Contributing-guidelines#122-obligatory-tags)

Not done but might be a good idea:
* Change package id to lowercase
* Add logo to this repository to avoid linking to another repository