### PR TITLE
(GH-405) Moved hard coded text strings to resource file

### DIFF
--- a/Source/ChocolateyGui/Bootstrapper.cs
+++ b/Source/ChocolateyGui/Bootstrapper.cs
@@ -14,6 +14,7 @@ using Autofac;
 using Caliburn.Micro;
 using CefSharp;
 using chocolatey;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Startup;
 using ChocolateyGui.ViewModels;
 using Serilog;
@@ -154,7 +155,7 @@ namespace ChocolateyGui
                 Logger.Fatal("Unhandled Exception", e.ExceptionObject as Exception);
                 MessageBox.Show(
                     e.ExceptionObject.ToString(),
-                    "Unhandled Exception",
+                    Resources.Bootstrapper_UnhandledException,
                     MessageBoxButton.OK,
                     MessageBoxImage.Error,
                     MessageBoxResult.OK,

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -488,7 +488,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.de.resx">

--- a/Source/ChocolateyGui/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui/Properties/Resources.Designer.cs
@@ -106,6 +106,69 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Details.
+        /// </summary>
+        public static string Controls_PackagesContextMenuDetails {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install.
+        /// </summary>
+        public static string Controls_PackagesContextMenuInstall {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pin.
+        /// </summary>
+        public static string Controls_PackagesContextMenuPin {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuPin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reinstall.
+        /// </summary>
+        public static string Controls_PackagesContextMenuReinstall {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuReinstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall.
+        /// </summary>
+        public static string Controls_PackagesContextMenuUninstall {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuUninstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unpin.
+        /// </summary>
+        public static string Controls_PackagesContextMenuUnpin {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuUnpin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update.
+        /// </summary>
+        public static string Controls_PackagesContextMenuUpdate {
+            get {
+                return ResourceManager.GetString("Controls_PackagesContextMenuUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid version string..
         /// </summary>
         public static string InvalidVersionString {
@@ -219,6 +282,15 @@ namespace ChocolateyGui.Properties {
         public static string PackageView_ButtonInstall {
             get {
                 return ResourceManager.GetString("PackageView_ButtonInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pin.
+        /// </summary>
+        public static string PackageView_ButtonPin {
+            get {
+                return ResourceManager.GetString("PackageView_ButtonPin", resourceCulture);
             }
         }
         
@@ -642,6 +714,15 @@ namespace ChocolateyGui.Properties {
         public static string SettingsView_SourcesCertificatePass {
             get {
                 return ResourceManager.GetString("SettingsView_SourcesCertificatePass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disabled.
+        /// </summary>
+        public static string SettingsView_SourcesDisabled {
+            get {
+                return ResourceManager.GetString("SettingsView_SourcesDisabled", resourceCulture);
             }
         }
         

--- a/Source/ChocolateyGui/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui/Properties/Resources.Designer.cs
@@ -70,11 +70,161 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unhandled Exception.
+        /// </summary>
+        public static string Bootstrapper_UnhandledException {
+            get {
+                return ResourceManager.GetString("Bootstrapper_UnhandledException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;h3&gt;Invalid HTML String&lt;/h3&gt;.
+        /// </summary>
+        public static string ChocolateyCustomSchemeProvider_InvalidHtml {
+            get {
+                return ResourceManager.GetString("ChocolateyCustomSchemeProvider_InvalidHtml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;h1&gt;Unknown Host&lt;/h1&gt;.
+        /// </summary>
+        public static string ChocolateyCustomSchemeProvider_UnknownHost {
+            get {
+                return ResourceManager.GetString("ChocolateyCustomSchemeProvider_UnknownHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Console Output.
         /// </summary>
         public static string ChocolateyDialog_ConsoleOutput {
             get {
                 return ResourceManager.GetString("ChocolateyDialog_ConsoleOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Escalating.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_Escalating {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_Escalating", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Exception: {0}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_ExceptionFormat {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_ExceptionFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exiting.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_Exiting {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_Exiting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install package &quot;{0}&quot;, version &quot;{1}&quot;.
+        ///Error: {2}{3}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_InstallFailedMessage {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_InstallFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install package..
+        /// </summary>
+        public static string ChocolateyRemotePackageService_InstallFailedTitle {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_InstallFailedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to pin package &quot;{0}&quot;, version &quot;{1}&quot;.
+        ///Error: {2}{3}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_PinFailedMessage {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_PinFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to pin package..
+        /// </summary>
+        public static string ChocolateyRemotePackageService_PinFailedTitle {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_PinFailedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to uninstall package &quot;{0}&quot;, version &quot;{1}&quot;.
+        ///Error: {2}{3}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UninstallFailedMessage {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UninstallFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to uninstall package..
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UninstallFailedTitle {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UninstallFailedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to unpin package &quot;{0}&quot;, version &quot;{1}&quot;.
+        ///Error {2}{3}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UnpinFailedMessage {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UnpinFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to unpin package..
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UnpinFailedTitle {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UnpinFailedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update package &quot;{0}&quot;.
+        ///Error: {1}{2}.
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UpdateFailedMessage {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UpdateFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update package..
+        /// </summary>
+        public static string ChocolateyRemotePackageService_UpdateFailedTitle {
+            get {
+                return ResourceManager.GetString("ChocolateyRemotePackageService_UpdateFailedTitle", resourceCulture);
             }
         }
         
@@ -268,6 +418,42 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Chocolatey.
+        /// </summary>
+        public static string LocalSourceViewModel_Chocolatey {
+            get {
+                return ResourceManager.GetString("LocalSourceViewModel_Chocolatey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Config Files (.config)|*.config.
+        /// </summary>
+        public static string LocalSourceViewModel_ConfigFiles {
+            get {
+                return ResourceManager.GetString("LocalSourceViewModel_ConfigFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packages.
+        /// </summary>
+        public static string LocalSourceViewModel_Packages {
+            get {
+                return ResourceManager.GetString("LocalSourceViewModel_Packages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There&apos;s an update available for chocolatey..
+        /// </summary>
+        public static string LocalSourceViewModel_UpdateAvailableForChocolatey {
+            get {
+                return ResourceManager.GetString("LocalSourceViewModel_UpdateAvailableForChocolatey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authors:.
         /// </summary>
         public static string PackageView_Authors {
@@ -457,6 +643,201 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package - {0}.
+        /// </summary>
+        public static string PackageViewModel_DisplayName {
+            get {
+                return ResourceManager.GetString("PackageViewModel_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install.
+        /// </summary>
+        public static string PackageViewModel_FailedToInstall {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Pin.
+        /// </summary>
+        public static string PackageViewModel_FailedToPin {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToPin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Reinstall.
+        /// </summary>
+        public static string PackageViewModel_FailedToReinstall {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToReinstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Uninstall.
+        /// </summary>
+        public static string PackageViewModel_FailedToUninstall {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToUninstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Unpin.
+        /// </summary>
+        public static string PackageViewModel_FailedToUnpin {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToUnpin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Update.
+        /// </summary>
+        public static string PackageViewModel_FailedToUpdate {
+            get {
+                return ResourceManager.GetString("PackageViewModel_FailedToUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing package.
+        /// </summary>
+        public static string PackageViewModel_InstallingPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_InstallingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading package information....
+        /// </summary>
+        public static string PackageViewModel_LoadingPackageInfo {
+            get {
+                return ResourceManager.GetString("PackageViewModel_LoadingPackageInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pinning package.
+        /// </summary>
+        public static string PackageViewModel_PinningPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_PinningPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while installing {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoInstallError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoInstallError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while pinning {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoPinningError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoPinningError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while reinstalling {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoReinstallError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoReinstallError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while uninstalling {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoUninstallError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoUninstallError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while unpinning {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoUnpinError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoUnpinError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ran into an error while updating {0}.
+        ///{1}.
+        /// </summary>
+        public static string PackageViewModel_RanIntoUpdateError {
+            get {
+                return ResourceManager.GetString("PackageViewModel_RanIntoUpdateError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reinstalling package.
+        /// </summary>
+        public static string PackageViewModel_ReinstallingPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_ReinstallingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} {1}....
+        /// </summary>
+        public static string PackageViewModel_StartLoadingFormat {
+            get {
+                return ResourceManager.GetString("PackageViewModel_StartLoadingFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstalling package.
+        /// </summary>
+        public static string PackageViewModel_UninstallingPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_UninstallingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unpinning package.
+        /// </summary>
+        public static string PackageViewModel_UnpinningPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_UnpinningPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updating package.
+        /// </summary>
+        public static string PackageViewModel_UpdatingPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_UpdatingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authors:.
         /// </summary>
         public static string RemoteSourceView_Authors {
@@ -552,6 +933,52 @@ namespace ChocolateyGui.Properties {
         public static string RemoteSourceView_SearchBoxText {
             get {
                 return ResourceManager.GetString("RemoteSourceView_SearchBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Load.
+        /// </summary>
+        public static string RemoteSourceViewModel_FailedToLoad {
+            get {
+                return ResourceManager.GetString("RemoteSourceViewModel_FailedToLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load remote packages!
+        ///{0}.
+        /// </summary>
+        public static string RemoteSourceViewModel_FailedToLoadRemotePackages {
+            get {
+                return ResourceManager.GetString("RemoteSourceViewModel_FailedToLoadRemotePackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Feed Search Error.
+        /// </summary>
+        public static string RemoteSourceViewModel_FeedSearchError {
+            get {
+                return ResourceManager.GetString("RemoteSourceViewModel_FeedSearchError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading page {0}....
+        /// </summary>
+        public static string RemoteSourceViewModel_LoadingPage {
+            get {
+                return ResourceManager.GetString("RemoteSourceViewModel_LoadingPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to connect to feed with Source: {0}.  Please check that this feed is accessible, and try again..
+        /// </summary>
+        public static string RemoteSourceViewModel_UnableToConnectToFeed {
+            get {
+                return ResourceManager.GetString("RemoteSourceViewModel_UnableToConnectToFeed", resourceCulture);
             }
         }
         
@@ -817,6 +1244,79 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ChocolateyGUI - Settings.
+        /// </summary>
+        public static string SettingsViewModel_DisplayName {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update features. Error:
+        ///{0}.
+        /// </summary>
+        public static string SettingsViewModel_FeatureFailedToUpdate {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_FeatureFailedToUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Feature Updates Error.
+        /// </summary>
+        public static string SettingsViewModel_FeatureUpdatesError {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_FeatureUpdatesError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing source....
+        /// </summary>
+        public static string SettingsViewModel_RemovingSource {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_RemovingSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Saving Source.
+        /// </summary>
+        public static string SettingsViewModel_SavingSource {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_SavingSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Saving source....
+        /// </summary>
+        public static string SettingsViewModel_SavingSourceLoading {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_SavingSourceLoading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source must have an Id!.
+        /// </summary>
+        public static string SettingsViewModel_SourceMissingId {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_SourceMissingId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source must have an value!.
+        /// </summary>
+        public static string SettingsViewModel_SourceMissingValue {
+            get {
+                return ResourceManager.GetString("SettingsViewModel_SourceMissingValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to about.
         /// </summary>
         public static string ShellView_ButtonAbout {
@@ -844,11 +1344,29 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Source - {0}.
+        /// </summary>
+        public static string SourcesViewModel_SourcesDisplayFormat {
+            get {
+                return ResourceManager.GetString("SourcesViewModel_SourcesDisplayFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to LineType must be a semantic version..
         /// </summary>
         public static string TypeMustBeASemanticVersion {
             get {
                 return ResourceManager.GetString("TypeMustBeASemanticVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version: {0}.
+        /// </summary>
+        public static string VersionNumberProvider_VersionFormat {
+            get {
+                return ResourceManager.GetString("VersionNumberProvider_VersionFormat", resourceCulture);
             }
         }
     }

--- a/Source/ChocolateyGui/Properties/Resources.resx
+++ b/Source/ChocolateyGui/Properties/Resources.resx
@@ -132,6 +132,27 @@
   <data name="Controls_PackageListTags" xml:space="preserve">
     <value>Tags:</value>
   </data>
+  <data name="Controls_PackagesContextMenuDetails" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="Controls_PackagesContextMenuInstall" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="Controls_PackagesContextMenuPin" xml:space="preserve">
+    <value>Pin</value>
+  </data>
+  <data name="Controls_PackagesContextMenuReinstall" xml:space="preserve">
+    <value>Reinstall</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUnpin" xml:space="preserve">
+    <value>Unpin</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUpdate" xml:space="preserve">
+    <value>Update</value>
+  </data>
   <data name="InvalidVersionString" xml:space="preserve">
     <value>Invalid version string.</value>
   </data>
@@ -170,6 +191,9 @@
   </data>
   <data name="PackageView_ButtonInstall" xml:space="preserve">
     <value>Install</value>
+  </data>
+  <data name="PackageView_ButtonPin" xml:space="preserve">
+    <value>Pin</value>
   </data>
   <data name="PackageView_ButtonReinstall" xml:space="preserve">
     <value>Reinstall</value>
@@ -311,6 +335,9 @@
   </data>
   <data name="SettingsView_SourcesCertificatePass" xml:space="preserve">
     <value>Certificate Pass</value>
+  </data>
+  <data name="SettingsView_SourcesDisabled" xml:space="preserve">
+    <value>Disabled</value>
   </data>
   <data name="SettingsView_SourcesId" xml:space="preserve">
     <value>Id</value>

--- a/Source/ChocolateyGui/Properties/Resources.resx
+++ b/Source/ChocolateyGui/Properties/Resources.resx
@@ -120,8 +120,62 @@
   <data name="Argument_cant_be_null_or_empty" xml:space="preserve">
     <value>Argument can't be null or empty.</value>
   </data>
+  <data name="Bootstrapper_UnhandledException" xml:space="preserve">
+    <value>Unhandled Exception</value>
+  </data>
+  <data name="ChocolateyCustomSchemeProvider_InvalidHtml" xml:space="preserve">
+    <value>&lt;h3&gt;Invalid HTML String&lt;/h3&gt;</value>
+  </data>
+  <data name="ChocolateyCustomSchemeProvider_UnknownHost" xml:space="preserve">
+    <value>&lt;h1&gt;Unknown Host&lt;/h1&gt;</value>
+  </data>
   <data name="ChocolateyDialog_ConsoleOutput" xml:space="preserve">
     <value>Console Output</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_Escalating" xml:space="preserve">
+    <value>Escalating</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_ExceptionFormat" xml:space="preserve">
+    <value>
+Exception: {0}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_Exiting" xml:space="preserve">
+    <value>Exiting</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_InstallFailedMessage" xml:space="preserve">
+    <value>Failed to install package "{0}", version "{1}".
+Error: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_InstallFailedTitle" xml:space="preserve">
+    <value>Failed to install package.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_PinFailedMessage" xml:space="preserve">
+    <value>Failed to pin package "{0}", version "{1}".
+Error: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_PinFailedTitle" xml:space="preserve">
+    <value>Failed to pin package.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UninstallFailedMessage" xml:space="preserve">
+    <value>Failed to uninstall package "{0}", version "{1}".
+Error: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UninstallFailedTitle" xml:space="preserve">
+    <value>Failed to uninstall package.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UnpinFailedMessage" xml:space="preserve">
+    <value>Failed to unpin package "{0}", version "{1}".
+Error {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UnpinFailedTitle" xml:space="preserve">
+    <value>Failed to unpin package.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UpdateFailedMessage" xml:space="preserve">
+    <value>Failed to update package "{0}".
+Error: {1}{2}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UpdateFailedTitle" xml:space="preserve">
+    <value>Failed to update package.</value>
   </data>
   <data name="Controls_PackageListByAuthor" xml:space="preserve">
     <value>By: </value>
@@ -156,6 +210,18 @@
   <data name="InvalidVersionString" xml:space="preserve">
     <value>Invalid version string.</value>
   </data>
+  <data name="LocalSourceViewModel_Chocolatey" xml:space="preserve">
+    <value>Chocolatey</value>
+  </data>
+  <data name="LocalSourceViewModel_ConfigFiles" xml:space="preserve">
+    <value>Config Files (.config)|*.config</value>
+  </data>
+  <data name="LocalSourceViewModel_Packages" xml:space="preserve">
+    <value>Packages</value>
+  </data>
+  <data name="LocalSourceViewModel_UpdateAvailableForChocolatey" xml:space="preserve">
+    <value>There's an update available for chocolatey.</value>
+  </data>
   <data name="LocalSourceView_ButtonExport" xml:space="preserve">
     <value>Export</value>
   </data>
@@ -185,6 +251,91 @@
   </data>
   <data name="LocalSourceView_SearchBoxText" xml:space="preserve">
     <value>Search:</value>
+  </data>
+  <data name="PackageViewModel_DisplayName" xml:space="preserve">
+    <value>Package - {0}</value>
+    <comment>{0} = Package Title</comment>
+  </data>
+  <data name="PackageViewModel_FailedToInstall" xml:space="preserve">
+    <value>Failed to install</value>
+  </data>
+  <data name="PackageViewModel_FailedToPin" xml:space="preserve">
+    <value>Failed to Pin</value>
+  </data>
+  <data name="PackageViewModel_FailedToReinstall" xml:space="preserve">
+    <value>Failed to Reinstall</value>
+  </data>
+  <data name="PackageViewModel_FailedToUninstall" xml:space="preserve">
+    <value>Failed to Uninstall</value>
+  </data>
+  <data name="PackageViewModel_FailedToUnpin" xml:space="preserve">
+    <value>Failed to Unpin</value>
+  </data>
+  <data name="PackageViewModel_FailedToUpdate" xml:space="preserve">
+    <value>Failed to Update</value>
+  </data>
+  <data name="PackageViewModel_InstallingPackage" xml:space="preserve">
+    <value>Installing package</value>
+  </data>
+  <data name="PackageViewModel_LoadingPackageInfo" xml:space="preserve">
+    <value>Loading package information...</value>
+  </data>
+  <data name="PackageViewModel_PinningPackage" xml:space="preserve">
+    <value>Pinning package</value>
+  </data>
+  <data name="PackageViewModel_RanIntoInstallError" xml:space="preserve">
+    <value>Ran into an error while installing {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoPinningError" xml:space="preserve">
+    <value>Ran into an error while pinning {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoReinstallError" xml:space="preserve">
+    <value>Ran into an error while reinstalling {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoUninstallError" xml:space="preserve">
+    <value>Ran into an error while uninstalling {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoUnpinError" xml:space="preserve">
+    <value>Ran into an error while unpinning {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoUpdateError" xml:space="preserve">
+    <value>Ran into an error while updating {0}.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_ReinstallingPackage" xml:space="preserve">
+    <value>Reinstalling package</value>
+  </data>
+  <data name="PackageViewModel_StartLoadingFormat" xml:space="preserve">
+    <value>{0} {1}...</value>
+    <comment>{0} = The command text
+{1} = The package id
+NOTE: Probably only necessary to change in RTL languages.</comment>
+  </data>
+  <data name="PackageViewModel_UninstallingPackage" xml:space="preserve">
+    <value>Uninstalling package</value>
+  </data>
+  <data name="PackageViewModel_UnpinningPackage" xml:space="preserve">
+    <value>Unpinning package</value>
+  </data>
+  <data name="PackageViewModel_UpdatingPackage" xml:space="preserve">
+    <value>Updating package</value>
   </data>
   <data name="PackageView_Authors" xml:space="preserve">
     <value>Authors:</value>
@@ -249,6 +400,24 @@
   <data name="PackageView_TotalDownloads" xml:space="preserve">
     <value>Total Downloads</value>
   </data>
+  <data name="RemoteSourceViewModel_FailedToLoad" xml:space="preserve">
+    <value>Failed to Load</value>
+  </data>
+  <data name="RemoteSourceViewModel_FailedToLoadRemotePackages" xml:space="preserve">
+    <value>Failed to load remote packages!
+{0}</value>
+    <comment>{0} = The exception message that occured</comment>
+  </data>
+  <data name="RemoteSourceViewModel_FeedSearchError" xml:space="preserve">
+    <value>Feed Search Error</value>
+  </data>
+  <data name="RemoteSourceViewModel_LoadingPage" xml:space="preserve">
+    <value>Loading page {0}...</value>
+    <comment>{0} = The page that is loading</comment>
+  </data>
+  <data name="RemoteSourceViewModel_UnableToConnectToFeed" xml:space="preserve">
+    <value>Unable to connect to feed with Source: {0}.  Please check that this feed is accessible, and try again.</value>
+  </data>
   <data name="RemoteSourceView_Authors" xml:space="preserve">
     <value>Authors:</value>
   </data>
@@ -284,6 +453,32 @@
   </data>
   <data name="Resources_ThisPC" xml:space="preserve">
     <value>This PC</value>
+  </data>
+  <data name="SettingsViewModel_DisplayName" xml:space="preserve">
+    <value>ChocolateyGUI - Settings</value>
+  </data>
+  <data name="SettingsViewModel_FeatureFailedToUpdate" xml:space="preserve">
+    <value>Failed to update features. Error:
+{0}</value>
+    <comment>{0} = The exception arguments</comment>
+  </data>
+  <data name="SettingsViewModel_FeatureUpdatesError" xml:space="preserve">
+    <value>Feature Updates Error</value>
+  </data>
+  <data name="SettingsViewModel_RemovingSource" xml:space="preserve">
+    <value>Removing source...</value>
+  </data>
+  <data name="SettingsViewModel_SavingSource" xml:space="preserve">
+    <value>Saving Source</value>
+  </data>
+  <data name="SettingsViewModel_SavingSourceLoading" xml:space="preserve">
+    <value>Saving source...</value>
+  </data>
+  <data name="SettingsViewModel_SourceMissingId" xml:space="preserve">
+    <value>Source must have an Id!</value>
+  </data>
+  <data name="SettingsViewModel_SourceMissingValue" xml:space="preserve">
+    <value>Source must have an value!</value>
   </data>
   <data name="SettingsView_About" xml:space="preserve">
     <value>About</value>
@@ -375,10 +570,17 @@
   <data name="ShellView_ButtonSettings" xml:space="preserve">
     <value>settings</value>
   </data>
+  <data name="SourcesViewModel_SourcesDisplayFormat" xml:space="preserve">
+    <value>Source - {0}</value>
+    <comment>{0} = The display name of the active item</comment>
+  </data>
   <data name="SourcesView_Choco" xml:space="preserve">
     <value>chocolatey</value>
   </data>
   <data name="TypeMustBeASemanticVersion" xml:space="preserve">
     <value>LineType must be a semantic version.</value>
+  </data>
+  <data name="VersionNumberProvider_VersionFormat" xml:space="preserve">
+    <value>Version: {0}</value>
   </data>
 </root>

--- a/Source/ChocolateyGui/Providers/ChocolateyCustomSchemeProvider.cs
+++ b/Source/ChocolateyGui/Providers/ChocolateyCustomSchemeProvider.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using CefSharp;
+using ChocolateyGui.Properties;
 
 namespace ChocolateyGui.Providers
 {
@@ -22,14 +23,14 @@ namespace ChocolateyGui.Providers
                 case "markdown":
                     if (request.PostData == null)
                     {
-                        return ResourceHandler.FromString("<h3>Invalid HTML String</h3>");
+                        return ResourceHandler.FromString(Resources.ChocolateyCustomSchemeProvider_InvalidHtml);
                     }
 
                     var postData = request.PostData.Elements.FirstOrDefault();
                     var markdown = postData.GetBody();
                     return ResourceHandler.FromString(markdown);
                 default:
-                    return ResourceHandler.FromString("<h1>Unknown Host</h1>");
+                    return ResourceHandler.FromString(Resources.ChocolateyCustomSchemeProvider_UnknownHost);
             }
         }
     }

--- a/Source/ChocolateyGui/Providers/VersionNumberProvider.cs
+++ b/Source/ChocolateyGui/Providers/VersionNumberProvider.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using System.Reflection;
+using ChocolateyGui.Properties;
 
 namespace ChocolateyGui.Providers
 {
@@ -27,7 +28,7 @@ namespace ChocolateyGui.Providers
                     ((AssemblyInformationalVersionAttribute[])assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute)))
                         .First();
 
-                _version = "Version: " + informational.InformationalVersion;
+                _version = string.Format(Resources.VersionNumberProvider_VersionFormat, informational.InformationalVersion);
                 return _version;
             }
         }

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -661,7 +661,7 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="Unpin" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUnpin}" Icon="{StaticResource UacIcon}"
                   Command="{commands:DataContextCommandAdapter Unpin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -649,10 +649,10 @@
     <ContextMenu x:Key="PackagesContextMenu"
                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
                  d:DataContext="{d:DesignInstance Type=items:PackageViewModel}">
-        <MenuItem Header="Install" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuInstall}" Icon="{StaticResource UacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"
                   Command="{commands:DataContextCommandAdapter Install}" />
-        <MenuItem Header="Pin" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuPin}" Icon="{StaticResource UacIcon}"
                   Command="{commands:DataContextCommandAdapter Pin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -670,16 +670,16 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="Uninstall" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUninstall}" Icon="{StaticResource UacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Uninstall}" />
-        <MenuItem Header="Reinstall" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuReinstall}" Icon="{StaticResource UacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Reinstall}" />
-        <MenuItem Header="Update" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUpdate}" Icon="{StaticResource UacIcon}"
                   Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Update}" />
-        <MenuItem Header="Details" Command="{commands:DataContextCommandAdapter ViewDetails}" />
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuDetails}" Command="{commands:DataContextCommandAdapter ViewDetails}" />
     </ContextMenu>
 
     <Style x:Key="PackagesGridStyle" TargetType="{x:Type DataGrid}">

--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -282,9 +282,7 @@ namespace ChocolateyGui.Services
         public void Dispose()
         {
             _logStream?.Dispose();
-            _wampChannel?.Close(
-                Resources.ChocolateyRemotePackageService_Exiting,
-                new GoodbyeDetails { Message = Resources.ChocolateyRemotePackageService_Exiting });
+            _wampChannel?.Close("Exiting", new GoodbyeDetails { Message = "Exiting" });
         }
 
         private async Task<bool> RequiresElevationImpl()
@@ -325,9 +323,7 @@ namespace ChocolateyGui.Services
                     _isInitialized = false;
                     _logStream.Dispose();
                     _logStream = null;
-                    _wampChannel.Close(
-                        Resources.ChocolateyRemotePackageService_Escalating,
-                        new GoodbyeDetails { Message = Resources.ChocolateyRemotePackageService_Escalating });
+                    _wampChannel.Close("Escalating", new GoodbyeDetails { Message = "Escalating" });
                     _wampChannel = null;
                     _chocolateyService = null;
 

--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -17,6 +17,7 @@ using AutoMapper;
 using Caliburn.Micro;
 using ChocolateyGui.Models;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Providers;
 using ChocolateyGui.Subprocess;
 using ChocolateyGui.Subprocess.Models;
@@ -107,10 +108,18 @@ namespace ChocolateyGui.Services
             var result = await _chocolateyService.InstallPackage(id, version?.ToString(), source, force);
             if (!result.Successful)
             {
-                var exceptionMessage = result.Exception == null ? string.Empty : $"\nException: {result.Exception}";
+                var exceptionMessage = result.Exception == null
+                    ? string.Empty
+                    : string.Format(Resources.ChocolateyRemotePackageService_ExceptionFormat, result.Exception);
+                var message = string.Format(
+                    Resources.ChocolateyRemotePackageService_InstallFailedMessage,
+                    id,
+                    version,
+                    string.Join("\n", result.Messages),
+                    exceptionMessage);
                 await _progressService.ShowMessageAsync(
-                    "Failed to install package.",
-                    $"Failed to install package \"{id}\", version \"{version}\".\nError: {string.Join("\n", result.Messages)}{exceptionMessage}");
+                    Resources.ChocolateyRemotePackageService_InstallFailedTitle,
+                    message);
                 Logger.Warning(result.Exception, "Failed to install {Package}, version {Version}. Errors: {Errors}", id, version, result.Messages);
                 return;
             }
@@ -124,10 +133,18 @@ namespace ChocolateyGui.Services
             var result = await _chocolateyService.UninstallPackage(id, version.ToString(), force);
             if (!result.Successful)
             {
-                var exceptionMessage = result.Exception == null ? string.Empty : $"\nException: {result.Exception}";
+                var exceptionMessage = result.Exception == null
+                    ? string.Empty
+                    : string.Format(Resources.ChocolateyRemotePackageService_ExceptionFormat, result.Exception);
+                var message = string.Format(
+                    Resources.ChocolateyRemotePackageService_UninstallFailedMessage,
+                    id,
+                    version,
+                    string.Join("\n", result.Messages),
+                    exceptionMessage);
                 await _progressService.ShowMessageAsync(
-                    "Failed to uninstall package.",
-                    $"Failed to uninstall package \"{id}\", version \"{version}\".\nError: {string.Join("\n", result.Messages)}{exceptionMessage}");
+                    Resources.ChocolateyRemotePackageService_UninstallFailedTitle,
+                    Resources.ChocolateyRemotePackageService_UninstallFailedMessage);
                 Logger.Warning(result.Exception, "Failed to uninstall {Package}, version {Version}. Errors: {Errors}", id, version, result.Messages);
                 return;
             }
@@ -141,10 +158,17 @@ namespace ChocolateyGui.Services
             var result = await _chocolateyService.UpdatePackage(id, source);
             if (!result.Successful)
             {
-                var exceptionMessage = result.Exception == null ? string.Empty : $"\nException: {result.Exception}";
+                var exceptionMessage = result.Exception == null
+                    ? string.Empty
+                    : string.Format(Resources.ChocolateyRemotePackageService_ExceptionFormat, result.Exception);
+                var message = string.Format(
+                    Resources.ChocolateyRemotePackageService_UpdateFailedMessage,
+                    id,
+                    string.Join("\n", result.Messages),
+                    exceptionMessage);
                 await _progressService.ShowMessageAsync(
-                    "Failed to update package.",
-                    $"Failed to update package \"{id}\".\nError: {string.Join("\n", result.Messages)}{exceptionMessage}");
+                    Resources.ChocolateyRemotePackageService_UpdateFailedTitle,
+                    Resources.ChocolateyRemotePackageService_UpdateFailedMessage);
                 Logger.Warning(result.Exception, "Failed to update {Package}. Errors: {Errors}", id, result.Messages);
                 return;
             }
@@ -158,10 +182,18 @@ namespace ChocolateyGui.Services
             var result = await _chocolateyService.PinPackage(id, version.ToString());
             if (!result.Successful)
             {
-                var exceptionMessage = result.Exception == null ? string.Empty : $"\nException: {result.Exception}";
+                var exceptionMessage = result.Exception == null
+                    ? string.Empty
+                    : string.Format(Resources.ChocolateyRemotePackageService_ExceptionFormat, result.Exception);
+                var message = string.Format(
+                    Resources.ChocolateyRemotePackageService_PinFailedMessage,
+                    id,
+                    version,
+                    string.Join("\n", result.Messages),
+                    exceptionMessage);
                 await _progressService.ShowMessageAsync(
-                    "Failed to pin package.",
-                    $"Failed to pin package \"{id}\", version \"{version}\".\nError: {string.Join("\n", result.Messages)}{exceptionMessage}");
+                    Resources.ChocolateyRemotePackageService_PinFailedTitle,
+                    message);
                 Logger.Warning(result.Exception, "Failed to pin {Package}, version {Version}. Errors: {Errors}", id, version, result.Messages);
                 return;
             }
@@ -175,10 +207,18 @@ namespace ChocolateyGui.Services
             var result = await _chocolateyService.UnpinPackage(id, version.ToString());
             if (!result.Successful)
             {
-                var exceptionMessage = result.Exception == null ? string.Empty : $"\nException: {result.Exception}";
+                var exceptionMessage = result.Exception == null
+                    ? string.Empty
+                    : string.Format(Resources.ChocolateyRemotePackageService_ExceptionFormat, result.Exception);
+                var message = string.Format(
+                    Resources.ChocolateyRemotePackageService_UnpinFailedMessage,
+                    id,
+                    version,
+                    string.Join("\n", result.Messages),
+                    exceptionMessage);
                 await _progressService.ShowMessageAsync(
-                    "Failed to unpin package.",
-                    $"Failed to unpin package \"{id}\", version \"{version}\".\nError: {string.Join("\n", result.Messages)}{exceptionMessage}");
+                    Resources.ChocolateyRemotePackageService_UninstallFailedTitle,
+                    message);
                 Logger.Warning(result.Exception, "Failed to unpin {Package}, version {Version}. Errors: {Errors}", id, version, result.Messages);
                 return;
             }
@@ -242,7 +282,9 @@ namespace ChocolateyGui.Services
         public void Dispose()
         {
             _logStream?.Dispose();
-            _wampChannel?.Close("Exiting", new GoodbyeDetails { Message = "Exiting" });
+            _wampChannel?.Close(
+                Resources.ChocolateyRemotePackageService_Exiting,
+                new GoodbyeDetails { Message = Resources.ChocolateyRemotePackageService_Exiting });
         }
 
         private async Task<bool> RequiresElevationImpl()
@@ -283,7 +325,9 @@ namespace ChocolateyGui.Services
                     _isInitialized = false;
                     _logStream.Dispose();
                     _logStream = null;
-                    _wampChannel.Close("Escalating", new GoodbyeDetails { Message = "Escalating" });
+                    _wampChannel.Close(
+                        Resources.ChocolateyRemotePackageService_Escalating,
+                        new GoodbyeDetails { Message = Resources.ChocolateyRemotePackageService_Escalating });
                     _wampChannel = null;
                     _chocolateyService = null;
 

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -336,10 +336,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while installing {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToInstall,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoInstallError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoInstallError, Id, ex.Message));
             }
         }
 
@@ -357,10 +354,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while reinstalling {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToReinstall,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoReinstallError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoReinstallError, Id, ex.Message));
             }
 
             await _eventAggregator.PublishOnUIThreadAsync(new PackageChangedMessage(Id, PackageChangeType.Installed, Version));
@@ -380,10 +374,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while uninstalling {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToUninstall,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoUninstallError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoUninstallError, Id, ex.Message));
             }
         }
 
@@ -401,10 +392,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while updating {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToUpdate,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoUpdateError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoUpdateError, Id, ex.Message));
             }
         }
 
@@ -422,10 +410,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while pinning {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToPin,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoPinningError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoPinningError, Id, ex.Message));
             }
         }
 
@@ -443,10 +428,7 @@ namespace ChocolateyGui.ViewModels.Items
                 Logger.Error(ex, "Ran into an error while unpinning {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
                     Resources.PackageViewModel_FailedToUnpin,
-                    string.Format(
-                        Resources.PackageViewModel_RanIntoUnpinError,
-                        Id,
-                        ex.Message));
+                    string.Format(Resources.PackageViewModel_RanIntoUnpinError, Id, ex.Message));
             }
         }
 

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -11,6 +11,7 @@ using AutoMapper;
 using Caliburn.Micro;
 using ChocolateyGui.Base;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Services;
 using NuGet;
 using MemoryCache = System.Runtime.Caching.MemoryCache;
@@ -325,7 +326,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Installing package", "Installing package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_InstallingPackage, Resources.PackageViewModel_InstallingPackage, Id))
                 {
                     await _chocolateyService.InstallPackage(Id, Version, Source).ConfigureAwait(false);
                 }
@@ -333,7 +334,12 @@ namespace ChocolateyGui.ViewModels.Items
             catch (Exception ex)
             {
                 Logger.Error(ex, "Ran into an error while installing {Id}, version {Version}.", Id, Version);
-                await _progressService.ShowMessageAsync("Failed to Install", $"Ran into an error while install {Id}.\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.PackageViewModel_FailedToInstall,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoInstallError,
+                        Id,
+                        ex.Message));
             }
         }
 
@@ -341,7 +347,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Reinstalling package", "Reinstalling package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_ReinstallingPackage, Resources.PackageViewModel_ReinstallingPackage, Id))
                 {
                     await _chocolateyService.InstallPackage(Id, Version, Source, true).ConfigureAwait(false);
                 }
@@ -349,7 +355,12 @@ namespace ChocolateyGui.ViewModels.Items
             catch (Exception ex)
             {
                 Logger.Error(ex, "Ran into an error while reinstalling {Id}, version {Version}.", Id, Version);
-                await _progressService.ShowMessageAsync("Failed to Reinstall", $"Ran into an error while reinstalling {Id}.\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.PackageViewModel_FailedToReinstall,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoReinstallError,
+                        Id,
+                        ex.Message));
             }
 
             await _eventAggregator.PublishOnUIThreadAsync(new PackageChangedMessage(Id, PackageChangeType.Installed, Version));
@@ -359,7 +370,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Uninstalling package", "Uninstalling package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_UninstallingPackage, Resources.PackageViewModel_UninstallingPackage, Id))
                 {
                     await _chocolateyService.UninstallPackage(Id, Version, true).ConfigureAwait(false);
                 }
@@ -367,7 +378,12 @@ namespace ChocolateyGui.ViewModels.Items
             catch (Exception ex)
             {
                 Logger.Error(ex, "Ran into an error while uninstalling {Id}, version {Version}.", Id, Version);
-                await _progressService.ShowMessageAsync("Failed to Uninstall", $"Ran into an error while uninstalling {Id}.\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.PackageViewModel_FailedToUninstall,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoUninstallError,
+                        Id,
+                        ex.Message));
             }
         }
 
@@ -375,7 +391,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Updating package", "Updating package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_UpdatingPackage, Resources.PackageViewModel_UpdatingPackage, Id))
                 {
                     await _chocolateyService.UpdatePackage(Id, Source).ConfigureAwait(false);
                 }
@@ -384,8 +400,11 @@ namespace ChocolateyGui.ViewModels.Items
             {
                 Logger.Error(ex, "Ran into an error while updating {Id}, version {Version}.", Id, Version);
                 await _progressService.ShowMessageAsync(
-                    "Failed to Update",
-                    $"Ran into an error while updating {Id}.\n{ex.Message}");
+                    Resources.PackageViewModel_FailedToUpdate,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoUpdateError,
+                        Id,
+                        ex.Message));
             }
         }
 
@@ -393,7 +412,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Pinning package", "Pinning package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_PinningPackage, Resources.PackageViewModel_PinningPackage, Id))
                 {
                     await _chocolateyService.PinPackage(Id, Version).ConfigureAwait(false);
                 }
@@ -401,7 +420,12 @@ namespace ChocolateyGui.ViewModels.Items
             catch (Exception ex)
             {
                 Logger.Error(ex, "Ran into an error while pinning {Id}, version {Version}.", Id, Version);
-                await _progressService.ShowMessageAsync("Failed to Pin", $"Ran into an error while pinning {Id}.\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.PackageViewModel_FailedToPin,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoPinningError,
+                        Id,
+                        ex.Message));
             }
         }
 
@@ -409,7 +433,7 @@ namespace ChocolateyGui.ViewModels.Items
         {
             try
             {
-                using (await StartProgressDialog("Installing package", "Installing package", Id))
+                using (await StartProgressDialog(Resources.PackageViewModel_UnpinningPackage, Resources.PackageViewModel_UnpinningPackage, Id))
                 {
                     await _chocolateyService.UnpinPackage(Id, Version).ConfigureAwait(false);
                 }
@@ -417,7 +441,12 @@ namespace ChocolateyGui.ViewModels.Items
             catch (Exception ex)
             {
                 Logger.Error(ex, "Ran into an error while unpinning {Id}, version {Version}.", Id, Version);
-                await _progressService.ShowMessageAsync("Failed to Unpin", $"Ran into an error while unpinning {Id}.\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.PackageViewModel_FailedToUnpin,
+                    string.Format(
+                        Resources.PackageViewModel_RanIntoUnpinError,
+                        Id,
+                        ex.Message));
             }
         }
 
@@ -477,7 +506,7 @@ namespace ChocolateyGui.ViewModels.Items
 
         private async Task PopulateDetails()
         {
-            await _progressService.StartLoading("Loading package information...");
+            await _progressService.StartLoading(Resources.PackageViewModel_LoadingPackageInfo);
             try
             {
                 var package =
@@ -497,7 +526,7 @@ namespace ChocolateyGui.ViewModels.Items
 
         private async Task<IDisposable> StartProgressDialog(string commandString, string initialProgressText, string id = "")
         {
-            await _progressService.StartLoading($"{commandString} {id}...");
+            await _progressService.StartLoading(string.Format(Resources.PackageViewModel_StartLoadingFormat, commandString, id));
             _progressService.WriteMessage(initialProgressText);
             return new DisposableAction(() => _progressService.StopLoading());
         }

--- a/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Caliburn.Micro;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Services;
 using ChocolateyGui.Utilities.Extensions;
 using ChocolateyGui.ViewModels.Items;
@@ -121,7 +122,7 @@ namespace ChocolateyGui.ViewModels
         {
             try
             {
-                await _progressService.StartLoading("Packages", true);
+                await _progressService.StartLoading(Resources.LocalSourceViewModel_Packages, true);
                 var token = _progressService.GetCancellationToken();
                 var packages = Packages.Where(p => p.CanUpdate && !p.IsPinned).ToList();
                 double current = 0.0f;
@@ -154,7 +155,7 @@ namespace ChocolateyGui.ViewModels
 
             try
             {
-                var fileStream = _persistenceService.SaveFile("*.config", "Config Files (.config)|*.config");
+                var fileStream = _persistenceService.SaveFile("*.config", Resources.LocalSourceViewModel_ConfigFiles);
 
                 if (fileStream == null)
                 {
@@ -238,7 +239,7 @@ namespace ChocolateyGui.ViewModels
                 if (chocoPackage != null && chocoPackage.CanUpdate)
                 {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    _progressService.ShowMessageAsync("Chocolatey", "There's an update available for chocolatey.")
+                    _progressService.ShowMessageAsync(Resources.LocalSourceViewModel_Chocolatey, Resources.LocalSourceViewModel_UpdateAvailableForChocolatey)
                         .ConfigureAwait(false);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 }

--- a/Source/ChocolateyGui/ViewModels/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/PackageViewModel.cs
@@ -6,6 +6,7 @@
 
 using Caliburn.Micro;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.ViewModels.Items;
 
 namespace ChocolateyGui.ViewModels
@@ -21,7 +22,7 @@ namespace ChocolateyGui.ViewModels
 
         public IPackageViewModel Package { get; set; }
 
-        public new string DisplayName => $"Package - {Package?.Title}";
+        public new string DisplayName => string.Format(Resources.PackageViewModel_DisplayName, Package?.Title);
 
         public void Back()
         {

--- a/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using Caliburn.Micro;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Services;
 using ChocolateyGui.Subprocess.Models;
 using ChocolateyGui.Utilities.Extensions;
@@ -231,9 +232,9 @@ namespace ChocolateyGui.ViewModels
                 MessageBox.Show(
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "Unable to connect to feed with Source: {0}.  Please check that this feed is accessible, and try again.",
+                        Resources.RemoteSourceViewModel_UnableToConnectToFeed,
                         Source.Value),
-                    "Feed Search Error",
+                    Resources.RemoteSourceViewModel_FeedSearchError,
                     MessageBoxButton.OK,
                     MessageBoxImage.Error,
                     MessageBoxResult.OK,
@@ -249,7 +250,7 @@ namespace ChocolateyGui.ViewModels
 
                 var sort = SortSelection == "Popularity" ? "DownloadCount" : "Title";
 
-                await _progressService.StartLoading($"Loading page {CurrentPage}...");
+                await _progressService.StartLoading(string.Format(Resources.RemoteSourceViewModel_LoadingPage, CurrentPage));
                 try
                 {
                     var result =
@@ -294,7 +295,11 @@ namespace ChocolateyGui.ViewModels
             catch (Exception ex)
             {
                 Logger.Error(ex, "Failed to load new packages.");
-                await _progressService.ShowMessageAsync("Failed to Load", $"Failed to load remote packages!\n{ex.Message}");
+                await _progressService.ShowMessageAsync(
+                    Resources.RemoteSourceViewModel_FailedToLoad,
+                    string.Format(
+                        Resources.RemoteSourceViewModel_FailedToLoadRemotePackages,
+                        ex.Message));
                 throw;
             }
         }

--- a/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
@@ -297,9 +297,7 @@ namespace ChocolateyGui.ViewModels
                 Logger.Error(ex, "Failed to load new packages.");
                 await _progressService.ShowMessageAsync(
                     Resources.RemoteSourceViewModel_FailedToLoad,
-                    string.Format(
-                        Resources.RemoteSourceViewModel_FailedToLoadRemotePackages,
-                        ex.Message));
+                    string.Format(Resources.RemoteSourceViewModel_FailedToLoadRemotePackages, ex.Message));
                 throw;
             }
         }

--- a/Source/ChocolateyGui/ViewModels/SettingsViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SettingsViewModel.cs
@@ -297,9 +297,7 @@ namespace ChocolateyGui.ViewModels
             Logger.Error(ex, "Failed to update features list!\nMessage: {Message}\nArguments: {Arguments}", ex.Message, ex.Arguments);
             await _progressService.ShowMessageAsync(
                 Resources.SettingsViewModel_FeatureUpdatesError,
-                string.Format(
-                    Resources.SettingsViewModel_FeatureFailedToUpdate,
-                    string.Join("\v", ex.Arguments)));
+                string.Format(Resources.SettingsViewModel_FeatureFailedToUpdate, string.Join("\v", ex.Arguments)));
         }
     }
 }

--- a/Source/ChocolateyGui/ViewModels/SettingsViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SettingsViewModel.cs
@@ -15,6 +15,7 @@ using System.Windows.Controls;
 using Caliburn.Micro;
 using ChocolateyGui.Models;
 using ChocolateyGui.Models.Messages;
+using ChocolateyGui.Properties;
 using ChocolateyGui.Services;
 using ChocolateyGui.Subprocess.Models;
 using ChocolateyGui.Utilities.Extensions;
@@ -59,7 +60,7 @@ namespace ChocolateyGui.ViewModels
             _progressService = progressService;
             _configService = configService;
             _eventAggregator = eventAggregator;
-            DisplayName = "ChocolateyGUI - Settings";
+            DisplayName = Resources.SettingsViewModel_DisplayName;
             Activated += OnActivated;
             Deactivated += OnDeactivated;
         }
@@ -185,17 +186,17 @@ namespace ChocolateyGui.ViewModels
         {
             if (string.IsNullOrWhiteSpace(SelectedSource.Id))
             {
-                await _progressService.ShowMessageAsync("Saving Source", "Source must have an Id!");
+                await _progressService.ShowMessageAsync(Resources.SettingsViewModel_SavingSource, Resources.SettingsViewModel_SourceMissingId);
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(SelectedSource.Value))
             {
-                await _progressService.ShowMessageAsync("Saving Source", "Source must have an value!");
+                await _progressService.ShowMessageAsync(Resources.SettingsViewModel_SavingSource, Resources.SettingsViewModel_SourceMissingValue);
                 return;
             }
 
-            await _progressService.StartLoading("Saving source...");
+            await _progressService.StartLoading(Resources.SettingsViewModel_SavingSourceLoading);
             try
             {
                 if (_isNewItem)
@@ -221,7 +222,7 @@ namespace ChocolateyGui.ViewModels
 
         public async void Remove()
         {
-            await _progressService.StartLoading("Removing source...");
+            await _progressService.StartLoading(Resources.SettingsViewModel_RemovingSource);
             try
             {
                 await _packageService.RemoveSource(_originalId);
@@ -295,8 +296,10 @@ namespace ChocolateyGui.ViewModels
         {
             Logger.Error(ex, "Failed to update features list!\nMessage: {Message}\nArguments: {Arguments}", ex.Message, ex.Arguments);
             await _progressService.ShowMessageAsync(
-                "Feature Updates Error",
-                $"Failed to update features. Error:\n{string.Join("\v", ex.Arguments)}");
+                Resources.SettingsViewModel_FeatureUpdatesError,
+                string.Format(
+                    Resources.SettingsViewModel_FeatureFailedToUpdate,
+                    string.Join("\v", ex.Arguments)));
         }
     }
 }

--- a/Source/ChocolateyGui/ViewModels/SourcesViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SourcesViewModel.cs
@@ -90,7 +90,7 @@ namespace ChocolateyGui.ViewModels
         {
             Observable.FromEventPattern<PropertyChangedEventArgs>(this, nameof(PropertyChanged))
                 .Where(p => p.EventArgs.PropertyName == nameof(ActiveItem))
-                .Subscribe(p => DisplayName = $"Source - {ActiveItem.DisplayName}");
+                .Subscribe(p => DisplayName = $"Source - {ActiveItem?.DisplayName}");
 
             if (_firstLoad)
             {

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -78,7 +78,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource UacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="Pin" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonInstall}" FontSize="16"/>
+																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonPin}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                         <Button Padding="10" Margin="5 0"

--- a/Source/ChocolateyGui/Views/SettingsView.xaml
+++ b/Source/ChocolateyGui/Views/SettingsView.xaml
@@ -112,7 +112,7 @@
 														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificate}" Width="*" Binding="{Binding Certificate}" />
 														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificatePass}" Width="*" Binding="{Binding CertificatePassword}" />
 														<metro:DataGridNumericUpDownColumn Header="{x:Static lang:Resources.SettingsView_SourcesPriority}" Binding="{Binding Priority}"/>
-                            <DataGridCheckBoxColumn Header="Disabled" Width="Auto" Binding="{Binding Disabled}"/>
+                            <DataGridCheckBoxColumn Header="{x:Static lang:Resources.SettingsView_SourcesDisabled}" Width="Auto" Binding="{Binding Disabled}"/>
                         </DataGrid.Columns>
                     </DataGrid>
                     <DockPanel Grid.Row="2" Grid.Column="0" Margin="5">


### PR DESCRIPTION
A few text and header attributes in the xaml files was not moved to the Resource.resx file.
this PR fixes that.
It also changes ResXFileCodeGenerator to PublicResXFileCodeGenerator so that if new strings are added to the Resource.rex file or the designer is regenerated it will make the properties public (which is needed to be able to use them in xaml).

#405 