### PR TITLE
(GH-372) Dynamically select open port for subprocess

### DIFF
--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -370,7 +370,6 @@ namespace ChocolateyGui.Services
                     }
                 }
 
-
                 var factory = new WampChannelFactory();
                 _wampChannel =
                     factory.ConnectToRealm("default")
@@ -432,7 +431,7 @@ namespace ChocolateyGui.Services
                                            $"You can check the log file at {Path.Combine(Bootstrapper.AppDataPath, "ChocolateyGui.Subprocess.[Date].log")} for errors");
         }
 
-        private static bool IsPortAvailable(int port)
+        private bool IsPortAvailable(int port)
         {
             return IPGlobalProperties
                 .GetIPGlobalProperties()

--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -296,11 +297,21 @@ namespace ChocolateyGui.Services
                     }
                 }
 
-                const string Port = "24606";
+                var port = 5000;
+                while (!IsPortAvailable(port) && port < 6000)
+                {
+                    port++;
+                }
+
+                if (port >= 6000)
+                {
+                    throw new Exception("Failed to acquire port for GUI Subprocess.");
+                }
+
                 var subprocessPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ChocolateyGui.Subprocess.exe");
                 var startInfo = new ProcessStartInfo
                                     {
-                                        Arguments = Port,
+                                        Arguments = port.ToString(),
                                         UseShellExecute = true,
                                         FileName = subprocessPath,
                                         WindowStyle = ProcessWindowStyle.Hidden
@@ -359,10 +370,11 @@ namespace ChocolateyGui.Services
                     }
                 }
 
+
                 var factory = new WampChannelFactory();
                 _wampChannel =
                     factory.ConnectToRealm("default")
-                        .WebSocketTransport($"ws://127.0.0.1:{Port}/ws")
+                        .WebSocketTransport($"ws://127.0.0.1:{port}/ws")
                         .JsonSerialization()
                         .Build();
 
@@ -418,6 +430,14 @@ namespace ChocolateyGui.Services
             throw new ApplicationException($"Failed to start chocolatey subprocess.\n"
                                            +
                                            $"You can check the log file at {Path.Combine(Bootstrapper.AppDataPath, "ChocolateyGui.Subprocess.[Date].log")} for errors");
+        }
+
+        private static bool IsPortAvailable(int port)
+        {
+            return IPGlobalProperties
+                .GetIPGlobalProperties()
+                .GetActiveTcpListeners()
+                .All(tcpi => tcpi.Port != port);
         }
     }
 }


### PR DESCRIPTION
Currently Chocolatey GUI will attempt to acquire a static port, and simply fail if this port is already in use. This change has GUI check for an available port, and only fail if it can't find one open in an available range. 

(This was already already implemented in Subprocess, it was just never brought over to GUI side).