### PR TITLE
(GH-404) Added Norwegian Bokmål translation

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -385,6 +385,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <EmbeddedResource Include="Properties\Resources.nb.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/Source/ChocolateyGui/Properties/Resources.nb.resx
+++ b/Source/ChocolateyGui/Properties/Resources.nb.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Argument_cant_be_null_or_empty" xml:space="preserve">
-    <value>Tomt eller null argument er ikke gyldig.</value>
-  </data>
   <data name="ChocolateyDialog_ConsoleOutput" xml:space="preserve">
     <value>Konsolltekst</value>
   </data>
@@ -129,8 +126,8 @@
   <data name="Controls_PackageListDownloads" xml:space="preserve">
     <value>nedlastinger</value>
   </data>
-  <data name="InvalidVersionString" xml:space="preserve">
-    <value>Ugyldig versjonsstreng.</value>
+  <data name="SettingsView_On" xml:space="preserve">
+    <value>På</value>
   </data>
   <data name="LocalSourceView_ButtonExport" xml:space="preserve">
     <value>Eksporter</value>
@@ -372,15 +369,12 @@
   <data name="ChocolateyCustomSchemeProvider_UnknownHost" xml:space="preserve">
     <value>&lt;h1&gt;Ukjent vert&lt;/h1&gt;</value>
   </data>
-  <data name="ChocolateyRemotePackageService_Escalating" xml:space="preserve">
-    <value>Eskalerer</value>
+  <data name="SettingsView_Off" xml:space="preserve">
+    <value>Av</value>
   </data>
   <data name="ChocolateyRemotePackageService_ExceptionFormat" xml:space="preserve">
     <value>
 Unntak: {0}</value>
-  </data>
-  <data name="ChocolateyRemotePackageService_Exiting" xml:space="preserve">
-    <value>Avslutter</value>
   </data>
   <data name="ChocolateyRemotePackageService_InstallFailedMessage" xml:space="preserve">
     <value>Installeringen av pakken "{0}", versjon "{1}" feilet.
@@ -525,12 +519,6 @@ Feil: {2}{3}</value>
   </data>
   <data name="SettingsViewModel_SavingSourceLoading" xml:space="preserve">
     <value>Lagrer kilde...</value>
-  </data>
-  <data name="SourcesViewModel_SourcesDisplayFormat" xml:space="preserve">
-    <value>Kilde - {0}</value>
-  </data>
-  <data name="TypeMustBeASemanticVersion" xml:space="preserve">
-    <value>Linjetype må være en gyldig semantisk versjon.</value>
   </data>
   <data name="VersionNumberProvider_VersionFormat" xml:space="preserve">
     <value>Versjon: {0}</value>

--- a/Source/ChocolateyGui/Properties/Resources.nb.resx
+++ b/Source/ChocolateyGui/Properties/Resources.nb.resx
@@ -1,0 +1,553 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Argument_cant_be_null_or_empty" xml:space="preserve">
+    <value>Tomt eller null argument er ikke gyldig.</value>
+  </data>
+  <data name="ChocolateyDialog_ConsoleOutput" xml:space="preserve">
+    <value>Konsolltekst</value>
+  </data>
+  <data name="Controls_PackageListByAuthor" xml:space="preserve">
+    <value>Av: </value>
+  </data>
+  <data name="Controls_PackageListDownloads" xml:space="preserve">
+    <value>nedlastinger</value>
+  </data>
+  <data name="InvalidVersionString" xml:space="preserve">
+    <value>Ugyldig versjonsstreng.</value>
+  </data>
+  <data name="LocalSourceView_ButtonExport" xml:space="preserve">
+    <value>Eksporter</value>
+  </data>
+  <data name="LocalSourceView_ButtonRefreshPkgs" xml:space="preserve">
+    <value>Oppdater pakkeliste</value>
+  </data>
+  <data name="LocalSourceView_ButtonUpdateAll" xml:space="preserve">
+    <value>Oppdater alle</value>
+  </data>
+  <data name="LocalSourceView_CheckboxPkgsWithUpdates" xml:space="preserve">
+    <value>Vis kun pakker med oppdateringer</value>
+  </data>
+  <data name="LocalSourceView_Grid_Authors" xml:space="preserve">
+    <value>Forfattere</value>
+  </data>
+  <data name="LocalSourceView_Grid_LatestVersion" xml:space="preserve">
+    <value>Siste versjon</value>
+  </data>
+  <data name="LocalSourceView_Grid_Name" xml:space="preserve">
+    <value>Navn</value>
+  </data>
+  <data name="LocalSourceView_Grid_Version" xml:space="preserve">
+    <value>Versjon</value>
+  </data>
+  <data name="LocalSourceView_SearchBoxText" xml:space="preserve">
+    <value>Søk:</value>
+  </data>
+  <data name="PackageView_Authors" xml:space="preserve">
+    <value>Forfattere:</value>
+  </data>
+  <data name="PackageView_ButtonInstall" xml:space="preserve">
+    <value>Installer</value>
+  </data>
+  <data name="PackageView_ButtonReinstall" xml:space="preserve">
+    <value>Installer på nytt</value>
+  </data>
+  <data name="PackageView_ButtonUninstall" xml:space="preserve">
+    <value>Avinstaller</value>
+  </data>
+  <data name="PackageView_ButtonUnpin" xml:space="preserve">
+    <value>Løsne</value>
+  </data>
+  <data name="PackageView_ButtonUpdate" xml:space="preserve">
+    <value>Oppdater</value>
+  </data>
+  <data name="PackageView_Dependencies" xml:space="preserve">
+    <value>Avhengigheter</value>
+  </data>
+  <data name="PackageView_Description" xml:space="preserve">
+    <value>Beskrivelse</value>
+  </data>
+  <data name="PackageView_Downloads" xml:space="preserve">
+    <value>Nedlastinger</value>
+  </data>
+  <data name="PackageView_Gallery" xml:space="preserve">
+    <value>Galleri</value>
+  </data>
+  <data name="PackageView_LastUpdate" xml:space="preserve">
+    <value>Sist oppdatert</value>
+  </data>
+  <data name="PackageView_License" xml:space="preserve">
+    <value>Lisens</value>
+  </data>
+  <data name="PackageView_Maintainers" xml:space="preserve">
+    <value> | Vedlikeholdere: </value>
+  </data>
+  <data name="PackageView_PackageID" xml:space="preserve">
+    <value>Pakke-ID</value>
+  </data>
+  <data name="PackageView_PackageSize" xml:space="preserve">
+    <value>Pakkestørrelse</value>
+  </data>
+  <data name="PackageView_ProjectSite" xml:space="preserve">
+    <value>Prosjektside</value>
+  </data>
+  <data name="PackageView_ReleaseNotes" xml:space="preserve">
+    <value>Produktmerknader</value>
+  </data>
+  <data name="PackageView_ReportAbuse" xml:space="preserve">
+    <value>Rapporter misbruk</value>
+  </data>
+  <data name="PackageView_Summary" xml:space="preserve">
+    <value>Sammendrag</value>
+  </data>
+  <data name="PackageView_TotalDownloads" xml:space="preserve">
+    <value>Totalt nedlastet</value>
+  </data>
+  <data name="RemoteSourceView_Authors" xml:space="preserve">
+    <value>Forfattere:</value>
+  </data>
+  <data name="RemoteSourceView_ButtonGoBackAPage" xml:space="preserve">
+    <value>Gå tilbake en side</value>
+  </data>
+  <data name="RemoteSourceView_ButtonGoForwardAPage" xml:space="preserve">
+    <value>Neste</value>
+  </data>
+  <data name="RemoteSourceView_ButtonGotoFirstPage" xml:space="preserve">
+    <value>Gå til første side</value>
+  </data>
+  <data name="RemoteSourceView_ButtonGotoLastPage" xml:space="preserve">
+    <value>Siste</value>
+  </data>
+  <data name="RemoteSourceView_ButtonRefreshPkgs" xml:space="preserve">
+    <value>Oppdater pakkeliste</value>
+  </data>
+  <data name="RemoteSourceView_CheckboxAllVersions" xml:space="preserve">
+    <value>Alle versjoner</value>
+  </data>
+  <data name="RemoteSourceView_CheckboxIncludePrerelease" xml:space="preserve">
+    <value>Inkluder forhåndsversjoner</value>
+  </data>
+  <data name="RemoteSourceView_Downloads" xml:space="preserve">
+    <value>nedlastinger</value>
+  </data>
+  <data name="RemoteSourceView_SearchBoxText" xml:space="preserve">
+    <value>Søk:</value>
+  </data>
+  <data name="Resources_ThisPC" xml:space="preserve">
+    <value>Denne datamaskinen</value>
+  </data>
+  <data name="SettingsView_About" xml:space="preserve">
+    <value>Om</value>
+  </data>
+  <data name="SettingsView_ButtonCancel" xml:space="preserve">
+    <value>Avbryt</value>
+  </data>
+  <data name="SettingsView_ButtonNew" xml:space="preserve">
+    <value>Ny</value>
+  </data>
+  <data name="SettingsView_ButtonSave" xml:space="preserve">
+    <value>Lagre</value>
+  </data>
+  <data name="SettingsView_Credits" xml:space="preserve">
+    <value>Kreditering</value>
+  </data>
+  <data name="SettingsView_Features" xml:space="preserve">
+    <value>Funksjoner</value>
+  </data>
+  <data name="SettingsView_Options" xml:space="preserve">
+    <value>Alternativer</value>
+  </data>
+  <data name="SettingsView_PropertyDescription" xml:space="preserve">
+    <value>Beskrivelse</value>
+  </data>
+  <data name="SettingsView_PropertyName" xml:space="preserve">
+    <value>Navn</value>
+  </data>
+  <data name="SettingsView_PropertyValue" xml:space="preserve">
+    <value>Verdi</value>
+  </data>
+  <data name="SettingsView_ReleaseNotes" xml:space="preserve">
+    <value>Utgivelsesnotater</value>
+  </data>
+  <data name="SettingsView_Settings" xml:space="preserve">
+    <value>Innstillinger</value>
+  </data>
+  <data name="SettingsView_Sources" xml:space="preserve">
+    <value>Kilder</value>
+  </data>
+  <data name="SettingsView_SourcesCertificate" xml:space="preserve">
+    <value>Sertifikat</value>
+  </data>
+  <data name="SettingsView_SourcesCertificatePass" xml:space="preserve">
+    <value>Sertifikatpassord</value>
+  </data>
+  <data name="SettingsView_SourcesId" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="SettingsView_SourcesPassword" xml:space="preserve">
+    <value>Passord</value>
+  </data>
+  <data name="SettingsView_SourcesPriority" xml:space="preserve">
+    <value>Prioritet</value>
+  </data>
+  <data name="SettingsView_SourcesSource" xml:space="preserve">
+    <value>Kilde</value>
+  </data>
+  <data name="SettingsView_SourcesUsername" xml:space="preserve">
+    <value>Brukernavn</value>
+  </data>
+  <data name="SettingsView_ToggleShowConsoleOutput" xml:space="preserve">
+    <value>Vis konsolltekst</value>
+  </data>
+  <data name="ShellView_ButtonAbout" xml:space="preserve">
+    <value>om</value>
+  </data>
+  <data name="ShellView_ButtonSettings" xml:space="preserve">
+    <value>innstillinger</value>
+  </data>
+  <data name="SettingsView_SourcesPath" xml:space="preserve">
+    <value>Sti</value>
+  </data>
+  <data name="LocalSourceView_CheckboxMatchExact" xml:space="preserve">
+    <value>Kun nøyaktige treff</value>
+  </data>
+  <data name="RemoteSourceView_CheckboxMatchExactly" xml:space="preserve">
+    <value>Kun nøyaktige treff</value>
+  </data>
+  <data name="SettingsView_ButtonRemove" xml:space="preserve">
+    <value>Fjern</value>
+  </data>
+  <data name="SettingsView_SourcesIsDisabled" xml:space="preserve">
+    <value>Er deaktivert</value>
+  </data>
+  <data name="SettingsView_SourcesDisabled" xml:space="preserve">
+    <value>Deaktivert</value>
+  </data>
+  <data name="Controls_PackagesContextMenuInstall" xml:space="preserve">
+    <value>Installer</value>
+  </data>
+  <data name="Controls_PackagesContextMenuPin" xml:space="preserve">
+    <value>Fest</value>
+  </data>
+  <data name="Controls_PackagesContextMenuReinstall" xml:space="preserve">
+    <value>Installer på nytt</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUninstall" xml:space="preserve">
+    <value>Avinstaller</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUnpin" xml:space="preserve">
+    <value>Løsne</value>
+  </data>
+  <data name="Controls_PackagesContextMenuUpdate" xml:space="preserve">
+    <value>Oppdater</value>
+  </data>
+  <data name="Controls_PackagesContextMenuDetails" xml:space="preserve">
+    <value>Detaljer</value>
+  </data>
+  <data name="PackageView_ButtonPin" xml:space="preserve">
+    <value>Fest</value>
+  </data>
+  <data name="Bootstrapper_UnhandledException" xml:space="preserve">
+    <value>Ubehandlet unntak</value>
+  </data>
+  <data name="ChocolateyCustomSchemeProvider_InvalidHtml" xml:space="preserve">
+    <value>&lt;h3&gt;Ugyldig HTML&lt;/h3&gt;</value>
+  </data>
+  <data name="ChocolateyCustomSchemeProvider_UnknownHost" xml:space="preserve">
+    <value>&lt;h1&gt;Ukjent vert&lt;/h1&gt;</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_Escalating" xml:space="preserve">
+    <value>Eskalerer</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_ExceptionFormat" xml:space="preserve">
+    <value>
+Unntak: {0}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_Exiting" xml:space="preserve">
+    <value>Avslutter</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_InstallFailedMessage" xml:space="preserve">
+    <value>Installeringen av pakken "{0}", versjon "{1}" feilet.
+Feil: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_InstallFailedTitle" xml:space="preserve">
+    <value>Installering av pakke feilet.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_PinFailedMessage" xml:space="preserve">
+    <value>Festingen av pakken "{0}", versjon "{1}" feilet.
+Feil: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_PinFailedTitle" xml:space="preserve">
+    <value>Festing av pakke feilet.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UninstallFailedMessage" xml:space="preserve">
+    <value>Avinstalleringen av pakken "{0}", versjon "{1}" feilet.
+Feil: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UninstallFailedTitle" xml:space="preserve">
+    <value>Avinstallering av pakke feilet.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UnpinFailedMessage" xml:space="preserve">
+    <value>Løsningen av pakken "{0}", versjon "{1}" feilet.
+Feil: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UnpinFailedTitle" xml:space="preserve">
+    <value>Løsning av pakke feilet.</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UpdateFailedMessage" xml:space="preserve">
+    <value>Oppdateringen av pakken "{0}", versjon "{1}" feilet.
+Feil: {2}{3}</value>
+  </data>
+  <data name="ChocolateyRemotePackageService_UpdateFailedTitle" xml:space="preserve">
+    <value>Oppdatering av pakke feilet.</value>
+  </data>
+  <data name="LocalSourceViewModel_ConfigFiles" xml:space="preserve">
+    <value>Konfigurasjonsfiler (.config|*.config)</value>
+  </data>
+  <data name="LocalSourceViewModel_Packages" xml:space="preserve">
+    <value>Pakker</value>
+  </data>
+  <data name="LocalSourceViewModel_UpdateAvailableForChocolatey" xml:space="preserve">
+    <value>Det er en oppdatering tilgjengelig for chocolatey.</value>
+  </data>
+  <data name="PackageViewModel_DisplayName" xml:space="preserve">
+    <value>Pakke - {0}</value>
+  </data>
+  <data name="PackageViewModel_FailedToInstall" xml:space="preserve">
+    <value>Mislyktes i å installere</value>
+  </data>
+  <data name="PackageViewModel_FailedToPin" xml:space="preserve">
+    <value>Mislyktes i å feste</value>
+  </data>
+  <data name="PackageViewModel_FailedToReinstall" xml:space="preserve">
+    <value>Mislyktes i å installere på nytt</value>
+  </data>
+  <data name="PackageViewModel_FailedToUninstall" xml:space="preserve">
+    <value>Mislyktes i å avinstallere</value>
+  </data>
+  <data name="PackageViewModel_FailedToUnpin" xml:space="preserve">
+    <value>Mislyktes i å løsne</value>
+  </data>
+  <data name="PackageViewModel_FailedToUpdate" xml:space="preserve">
+    <value>Mislyktes i å oppdatere</value>
+  </data>
+  <data name="PackageViewModel_InstallingPackage" xml:space="preserve">
+    <value>Installerer pakke</value>
+  </data>
+  <data name="PackageViewModel_LoadingPackageInfo" xml:space="preserve">
+    <value>Laster inn pakkeinformasjon...</value>
+  </data>
+  <data name="PackageViewModel_PinningPackage" xml:space="preserve">
+    <value>Fester pakke</value>
+  </data>
+  <data name="PackageViewModel_RanIntoInstallError" xml:space="preserve">
+    <value>Det oppsto en feil under installeringen av {0}.
+{1}</value>
+  </data>
+  <data name="PackageViewModel_RanIntoPinningError" xml:space="preserve">
+    <value>Det oppsto en feil under festingen av {0}.
+{1}</value>
+  </data>
+  <data name="PackageViewModel_RanIntoReinstallError" xml:space="preserve">
+    <value>Det oppsto en feil under førsøket på å installere {0} på nytt.
+{1}</value>
+    <comment>{0} = The package Id
+{1} = The exception message</comment>
+  </data>
+  <data name="PackageViewModel_RanIntoUninstallError" xml:space="preserve">
+    <value>Det oppsto en feil under avinstalleringen av {0}.
+{1}</value>
+  </data>
+  <data name="PackageViewModel_RanIntoUnpinError" xml:space="preserve">
+    <value>Det oppsto en feil under løsningen av {0}.
+{1}</value>
+  </data>
+  <data name="PackageViewModel_RanIntoUpdateError" xml:space="preserve">
+    <value>Det oppsto en feil under oppdateringen av {0}.
+{1}</value>
+  </data>
+  <data name="PackageViewModel_ReinstallingPackage" xml:space="preserve">
+    <value>Installerer pakke på nytt</value>
+  </data>
+  <data name="PackageViewModel_UninstallingPackage" xml:space="preserve">
+    <value>Avinstallerer pakke</value>
+  </data>
+  <data name="PackageViewModel_UnpinningPackage" xml:space="preserve">
+    <value>Løsner pakke</value>
+  </data>
+  <data name="PackageViewModel_UpdatingPackage" xml:space="preserve">
+    <value>Oppdaterer pakke</value>
+  </data>
+  <data name="RemoteSourceViewModel_FailedToLoad" xml:space="preserve">
+    <value>Kunne ikke laste inn</value>
+  </data>
+  <data name="RemoteSourceViewModel_FailedToLoadRemotePackages" xml:space="preserve">
+    <value>Kunne ikke laste inn eksterne pakker!
+{0}</value>
+  </data>
+  <data name="RemoteSourceViewModel_FeedSearchError" xml:space="preserve">
+    <value>Feil ved kanalsøk</value>
+  </data>
+  <data name="RemoteSourceViewModel_LoadingPage" xml:space="preserve">
+    <value>Laster inn side {0}...</value>
+  </data>
+  <data name="RemoteSourceViewModel_UnableToConnectToFeed" xml:space="preserve">
+    <value>Kunne ikke koble til kanal med kilden: {0}. Vennligst sjekk om denne kanalen er tilgjengelig, og prøv igjen.</value>
+  </data>
+  <data name="SettingsViewModel_FeatureFailedToUpdate" xml:space="preserve">
+    <value>Kunne ikke oppdater funksjoner. Feil:
+{0}</value>
+  </data>
+  <data name="SettingsViewModel_FeatureUpdatesError" xml:space="preserve">
+    <value>Funksjonsoppdatering feilet</value>
+  </data>
+  <data name="SettingsViewModel_RemovingSource" xml:space="preserve">
+    <value>Fjerner kilde...</value>
+  </data>
+  <data name="SettingsViewModel_SavingSource" xml:space="preserve">
+    <value>Lagrer kilde</value>
+  </data>
+  <data name="SettingsViewModel_SavingSourceLoading" xml:space="preserve">
+    <value>Lagrer kilde...</value>
+  </data>
+  <data name="SourcesViewModel_SourcesDisplayFormat" xml:space="preserve">
+    <value>Kilde - {0}</value>
+  </data>
+  <data name="TypeMustBeASemanticVersion" xml:space="preserve">
+    <value>Linjetype må være en gyldig semantisk versjon.</value>
+  </data>
+  <data name="VersionNumberProvider_VersionFormat" xml:space="preserve">
+    <value>Versjon: {0}</value>
+  </data>
+  <data name="Controls_PackageListTags" xml:space="preserve">
+    <value>Stikkord:</value>
+  </data>
+  <data name="SettingsViewModel_DisplayName" xml:space="preserve">
+    <value>ChocolateyGUI - Innstillinger</value>
+  </data>
+  <data name="SettingsViewModel_SourceMissingId" xml:space="preserve">
+    <value>Kilde må ha en ID!</value>
+  </data>
+  <data name="SettingsViewModel_SourceMissingValue" xml:space="preserve">
+    <value>Kilde må ha en verdi!</value>
+  </data>
+  <data name="SettingsView_ToggleElevateByDefault" xml:space="preserve">
+    <value>Administrator-rettigheter som standard</value>
+  </data>
+</root>


### PR DESCRIPTION
This is not a complete translation (as well as some of the translated entries could definitely be improved)

The following have not been translated:
- LocalSourceViewModel (no need to translate)
- PackageVewModel_StartLoadingFormat (Same format can be used in norwegian)
- SettingsView_SubheaderChoco (no need to translate)
- SettingsView_ToggleElevateByDefault (don't know what the correct translation would be)
- SourcesView_Choco (no need to translate)

fixes #404 