### PR TITLE
Add log level switch.

### DIFF
--- a/Source/ChocolateyGui.Subprocess/Program.cs
+++ b/Source/ChocolateyGui.Subprocess/Program.cs
@@ -31,14 +31,29 @@ namespace ChocolateyGui.Subprocess
 
             var logFolder = Path.Combine(appDataPath, "Logs");
             var directPath = Path.Combine(logFolder, "ChocolateyGui.Subprocess.{Date}.log");
+#if !DEBUG
+            var logLevel = Environment.GetEnvironmentVariable("CHOCOLATEYGUI__LOGLEVEL");
+#endif
 
-            Log.Logger = new LoggerConfiguration()
+            var logConfig = new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .WriteTo.Async(config => config.LiterateConsole())
                 .WriteTo.Async(config =>
-                    config.RollingFile(directPath, retainedFileCountLimit: 10, fileSizeLimitBytes: 150 * 1000 * 1000))
-                .CreateLogger();
-
+                    config.RollingFile(directPath, retainedFileCountLimit: 10, fileSizeLimitBytes: 150 * 1000 * 1000));
+#if DEBUG
+            logConfig.MinimumLevel.Debug();
+#else
+            Serilog.Events.LogEventLevel logEventLevel;
+            if (string.IsNullOrWhiteSpace(logLevel) || !Enum.TryParse(logLevel, true, out logEventLevel))
+            {
+                logConfig.MinimumLevel.Information();
+            }
+            else
+            {
+                logConfig.MinimumLevel.Is(Serilog.Events.LogEventLevel.Information);
+            }
+#endif
+            Log.Logger = logConfig.CreateLogger();
             Logger = Log.ForContext<Program>();
 
             var source = new CancellationTokenSource();

--- a/docs/input/credits.md
+++ b/docs/input/credits.md
@@ -44,7 +44,6 @@ ChocolateyGUI uses the following awesome frameworks (in no particular order):
 * [Splat](https://github.com/paulcbetts/splat)
 * [SQLLitePCLRaw](https://github.com/ericsink/SQLitePCL.raw)
 * [SuperSocket](http://www.supersocket.net/)
-* [WampSharp](https://github.com/Code-Sharp/WampSharp/)
 * [WebSocket4Net](http://websocket4net.codeplex.com/)
 
 ChocolateyGUI is built, with the following fantastic frameworks and services (in no particular order):


### PR DESCRIPTION
Exposes a simple undocumented env var for setting ChocolateyGUI's log level at runtime. 

Eventually I'll be adding a user toggleable switch to settings.

Var: `CHOCOLATEYGUI__LOGLEVEL`
Levels (Case insensitive and correspond to interneral Serilog levels):
```
        //
        // Summary:
        //     Anything and everything you might want to know about a running block of code.
        Verbose,
        //
        // Summary:
        //     Internal system events that aren't necessarily observable from the outside.
        Debug,
        //
        // Summary:
        //     The lifeblood of operational intelligence - things happen.
        Information,
        //
        // Summary:
        //     Service is degraded or endangered.
        Warning,
        //
        // Summary:
        //     Functionality is unavailable, invariants are broken or data is lost.
        Error,
        //
        // Summary:
        //     If you have a pager, it goes off when one of these occurs.
        Fatal
```