### PR TITLE
(GH-371) Enable self-service mode

### DIFF
--- a/Source/ChocolateyGui.Shared/ChocolateyGui.Shared.csproj
+++ b/Source/ChocolateyGui.Shared/ChocolateyGui.Shared.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="chocolatey, Version=0.10.6.1, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.10.6.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=0.10.7.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.0.10.7\lib\chocolatey.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>

--- a/Source/ChocolateyGui.Shared/Models/ChocolateySource.cs
+++ b/Source/ChocolateyGui.Shared/Models/ChocolateySource.cs
@@ -36,6 +36,10 @@ namespace ChocolateyGui.Models
         [DataMember]
         public string CertificatePassword { get; set; }
 
+        public bool ByPassProxy { get; set; }
+
+        public bool SelfService { get; set; }
+
         public bool Equals(ChocolateySource other)
         {
             if (ReferenceEquals(null, other))
@@ -48,10 +52,16 @@ namespace ChocolateyGui.Models
                 return true;
             }
 
-            return string.Equals(Id, other.Id) && string.Equals(Value, other.Value) && Disabled == other.Disabled
-                   && string.Equals(UserName, other.UserName) && string.Equals(Password, other.Password)
-                   && Priority == other.Priority && string.Equals(Certificate, other.Certificate)
-                   && string.Equals(CertificatePassword, other.CertificatePassword);
+            return string.Equals(Id, other.Id)
+                && string.Equals(Value, other.Value)
+                && Disabled == other.Disabled
+                && string.Equals(UserName, other.UserName)
+                && string.Equals(Password, other.Password)
+                && Priority == other.Priority
+                && string.Equals(Certificate, other.Certificate)
+                && string.Equals(CertificatePassword, other.CertificatePassword)
+                && ByPassProxy == other.ByPassProxy
+                && SelfService == other.SelfService;
         }
 
         public override bool Equals(object obj)
@@ -86,6 +96,8 @@ namespace ChocolateyGui.Models
                 hashCode = (hashCode * 397) ^ Priority;
                 hashCode = (hashCode * 397) ^ (Certificate?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (CertificatePassword?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ ByPassProxy.GetHashCode();
+                hashCode = (hashCode * 397) ^ SelfService.GetHashCode();
                 return hashCode;
             }
         }

--- a/Source/ChocolateyGui.Shared/packages.config
+++ b/Source/ChocolateyGui.Shared/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="chocolatey.lib" version="0.10.6.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="0.10.7" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Serilog" version="2.4.0" targetFramework="net452" />
 </packages>

--- a/Source/ChocolateyGui.Subprocess/ChocolateyGui.Subprocess.csproj
+++ b/Source/ChocolateyGui.Subprocess/ChocolateyGui.Subprocess.csproj
@@ -40,8 +40,9 @@
     <Reference Include="AutoMapper, Version=6.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.6.0.2\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.10.6.1, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.10.6.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=0.10.7.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.0.10.7\lib\chocolatey.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>

--- a/Source/ChocolateyGui.Subprocess/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Subprocess/ChocolateyService.cs
@@ -28,7 +28,7 @@ using ILogger = Serilog.ILogger;
 
 namespace ChocolateyGui.Subprocess
 {
-    [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerCall, ConcurrencyMode = ConcurrencyMode.Multiple)]
+    [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerCall, ConcurrencyMode = ConcurrencyMode.Multiple, IncludeExceptionDetailInFaults = true)]
     internal class ChocolateyService : IIpcChocolateyService
     {
 #pragma warning disable SA1401 // Fields must be private

--- a/Source/ChocolateyGui.Subprocess/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Subprocess/ChocolateyService.cs
@@ -419,6 +419,8 @@ namespace ChocolateyGui.Subprocess
                         config.SourceCommand.Certificate = source.Certificate;
                         config.SourceCommand.CertificatePassword = source.CertificatePassword;
                         config.SourceCommand.Priority = source.Priority;
+                        config.SourceCommand.BypassProxy = source.ByPassProxy;
+                        config.SourceCommand.AllowSelfService = source.SelfService;
                     });
 
                 await choco.RunAsync(operationContext.GetCancellationToken());

--- a/Source/ChocolateyGui.Subprocess/Program.cs
+++ b/Source/ChocolateyGui.Subprocess/Program.cs
@@ -18,6 +18,8 @@ using ILogger = Serilog.ILogger;
 
 namespace ChocolateyGui.Subprocess
 {
+    using chocolatey;
+
     public class Program
     {
         public static ManualResetEventSlim CanceledEvent { get; private set; }
@@ -49,6 +51,10 @@ namespace ChocolateyGui.Subprocess
                 CanceledEvent.Set();
                 source.Cancel();
             };
+
+            // Do not remove! Load Chocolatey once so all config gets set
+            // properly for future calls
+            var choco = Lets.GetChocolatey();
 
             CanceledEvent = new ManualResetEventSlim();
 

--- a/Source/ChocolateyGui.Subprocess/packages.config
+++ b/Source/ChocolateyGui.Subprocess/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="6.0.2" targetFramework="net452" />
-  <package id="chocolatey.lib" version="0.10.6.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="0.10.7" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.3.23" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net452" />

--- a/Source/ChocolateyGui/Base/ConnectionClosedException.cs
+++ b/Source/ChocolateyGui/Base/ConnectionClosedException.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="ConnectionClosedException.cs" company="Chocolatey">
+// Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+
+using System;
+
+namespace ChocolateyGui.Base
+{
+    /// <summary>
+    /// Used to represent that a connection closed peacefully while performing operation. Likely means application is closing.
+    /// </summary>
+    public class ConnectionClosedException : Exception
+    {
+    }
+}

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -233,7 +233,7 @@
     <Compile Include="Providers\ChocolateyConfigurationProvider.cs" />
     <Compile Include="Providers\ChocolateyCustomSchemeProvider.cs" />
     <Compile Include="Providers\ChocoRequestHandler.cs" />
-    <Compile Include="Providers\ElevationStatusProvider.cs" />
+    <Compile Include="Elevation.cs" />
     <Compile Include="Providers\IChocolateyConfigurationProvider.cs" />
     <Compile Include="Providers\IPlatformProvider.cs" />
     <Compile Include="Providers\IVersionNumberProvider.cs" />

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -183,6 +183,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Compile Include="Base\ConnectionClosedException.cs" />
     <Compile Include="Controls\InternetImage.xaml.cs">
       <DependentUpon>InternetImage.xaml</DependentUpon>
     </Compile>

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -60,8 +60,9 @@
     <Reference Include="Caliburn.Micro.Platform.Core, Version=3.0.3.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.1.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.10.6.1, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.10.6.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=0.10.7.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.0.10.7\lib\chocolatey.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="LiteDB, Version=3.1.0.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.3.1.0\lib\net35\LiteDB.dll</HintPath>

--- a/Source/ChocolateyGui/Elevation.cs
+++ b/Source/ChocolateyGui/Elevation.cs
@@ -1,0 +1,62 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Elevation.cs" company="Chocolatey">
+//  Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Autofac;
+using Caliburn.Micro;
+using ChocolateyGui.Utilities;
+using ChocolateyGui.Utilities.Extensions;
+
+namespace ChocolateyGui
+{
+    public class Elevation : PropertyChangedBase
+    {
+        private bool _isElevated = Hacks.IsElevated;
+        private bool _isBackgroundRunning = false;
+
+        public static Elevation Instance
+        {
+            get { return Bootstrapper.Container.Resolve<Elevation>(); }
+        }
+
+        public bool IsElevated
+        {
+            get
+            {
+                return _isElevated;
+            }
+
+            set
+            {
+                this.SetPropertyValue(ref _isElevated, value);
+                NotifyOfPropertyChange(nameof(CanDoCentralActions));
+            }
+        }
+
+        public bool IsBackgroundRunning
+        {
+            get
+            {
+                return _isBackgroundRunning;
+            }
+
+            set
+            {
+                this.SetPropertyValue(ref _isBackgroundRunning, value);
+                NotifyOfPropertyChange(nameof(CanDoCentralActions));
+            }
+        }
+
+        public bool CanDoCentralActions
+        {
+            get { return _isBackgroundRunning || _isElevated; }
+        }
+
+        public bool CanDoTertiaryActions
+        {
+            get { return _isElevated; }
+        }
+    }
+}

--- a/Source/ChocolateyGui/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui/Properties/Resources.Designer.cs
@@ -1127,6 +1127,15 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ByPass Proxy.
+        /// </summary>
+        public static string SettingsView_SourcesByPassProxy {
+            get {
+                return ResourceManager.GetString("SettingsView_SourcesByPassProxy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Certificate.
         /// </summary>
         public static string SettingsView_SourcesCertificate {
@@ -1163,11 +1172,29 @@ namespace ChocolateyGui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Is Proxy ByPassed.
+        /// </summary>
+        public static string SettingsView_SourcesIsByPassProxy {
+            get {
+                return ResourceManager.GetString("SettingsView_SourcesIsByPassProxy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Is Disabled.
         /// </summary>
         public static string SettingsView_SourcesIsDisabled {
             get {
                 return ResourceManager.GetString("SettingsView_SourcesIsDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Is Self Service.
+        /// </summary>
+        public static string SettingsView_SourcesIsSelfService {
+            get {
+                return ResourceManager.GetString("SettingsView_SourcesIsSelfService", resourceCulture);
             }
         }
         
@@ -1195,6 +1222,15 @@ namespace ChocolateyGui.Properties {
         public static string SettingsView_SourcesPriority {
             get {
                 return ResourceManager.GetString("SettingsView_SourcesPriority", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Self Service.
+        /// </summary>
+        public static string SettingsView_SourcesSelfService {
+            get {
+                return ResourceManager.GetString("SettingsView_SourcesSelfService", resourceCulture);
             }
         }
         

--- a/Source/ChocolateyGui/Properties/Resources.de.resx
+++ b/Source/ChocolateyGui/Properties/Resources.de.resx
@@ -303,6 +303,9 @@
   <data name="SettingsView_Sources" xml:space="preserve">
     <value>Quellen</value>
   </data>
+  <data name="SettingsView_SourcesByPassProxy" xml:space="preserve">
+    <value />
+  </data>
   <data name="SettingsView_SourcesCertificate" xml:space="preserve">
     <value>Zertifikat</value>
   </data>
@@ -323,6 +326,9 @@
   </data>
   <data name="SettingsView_SourcesPriority" xml:space="preserve">
     <value>Priorität</value>
+  </data>
+  <data name="SettingsView_SourcesSelfService" xml:space="preserve">
+    <value />
   </data>
   <data name="SettingsView_SourcesSource" xml:space="preserve">
     <value>Quelle</value>

--- a/Source/ChocolateyGui/Properties/Resources.de.resx
+++ b/Source/ChocolateyGui/Properties/Resources.de.resx
@@ -165,6 +165,9 @@
   <data name="PackageView_ButtonInstall" xml:space="preserve">
     <value>Installieren</value>
   </data>
+  <data name="PackageView_ButtonPin" xml:space="preserve">
+    <value>Pin</value>
+  </data>
   <data name="PackageView_ButtonReinstall" xml:space="preserve">
     <value>Erneut Installieren</value>
   </data>

--- a/Source/ChocolateyGui/Properties/Resources.resx
+++ b/Source/ChocolateyGui/Properties/Resources.resx
@@ -576,4 +576,16 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   <data name="VersionNumberProvider_VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>
+  <data name="SettingsView_SourcesByPassProxy" xml:space="preserve">
+    <value>ByPass Proxy</value>
+  </data>
+  <data name="SettingsView_SourcesSelfService" xml:space="preserve">
+    <value>Self Service</value>
+  </data>
+  <data name="SettingsView_SourcesIsByPassProxy" xml:space="preserve">
+    <value>Is Proxy ByPassed</value>
+  </data>
+  <data name="SettingsView_SourcesIsSelfService" xml:space="preserve">
+    <value>Is Self Service</value>
+  </data>
 </root>

--- a/Source/ChocolateyGui/Properties/Resources.sv.resx
+++ b/Source/ChocolateyGui/Properties/Resources.sv.resx
@@ -519,6 +519,9 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   <data name="SettingsView_Sources" xml:space="preserve">
     <value>Källor</value>
   </data>
+  <data name="SettingsView_SourcesByPassProxy" xml:space="preserve">
+    <value />
+  </data>
   <data name="SettingsView_SourcesCertificate" xml:space="preserve">
     <value>Certifikat</value>
   </data>
@@ -542,6 +545,9 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   </data>
   <data name="SettingsView_SourcesPriority" xml:space="preserve">
     <value>Prioritet</value>
+  </data>
+  <data name="SettingsView_SourcesSelfService" xml:space="preserve">
+    <value />
   </data>
   <data name="SettingsView_SourcesSource" xml:space="preserve">
     <value>Källa</value>

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -8,7 +8,7 @@
                     xmlns:converters="clr-namespace:ChocolateyGui.Utilities.Converters"
                     xmlns:commands="clr-namespace:ChocolateyGui.Commands"
                     xmlns:utilities="clr-namespace:ChocolateyGui.Utilities"
-                    xmlns:providers="clr-namespace:ChocolateyGui.Providers"
+                    xmlns:app="clr-namespace:ChocolateyGui"
                     xmlns:lang="clr-namespace:ChocolateyGui.Properties"
                     mc:Ignorable="d">
 
@@ -25,15 +25,31 @@
     <converters:StringListToString x:Key="StringListToString" />
     <converters:BooleanInverter x:Key="BooleanInverter" />
 
-    <providers:ElevationStatusProvider x:Key="Elevation" />
-    
     <Style x:Key="UacIconStyle" TargetType="{x:Type Image}">
         <Setter Property="Source" Value="{x:Static utilities:NativeMethods.UacIcon}"/>
-        <Setter Property="Visibility" Value="{Binding Path=IsElevated, Source={StaticResource Elevation}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
+        <Setter Property="Visibility" Value="{Binding Path=IsElevated, Source={x:Static app:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
     </Style>
 
     <Image x:Key="UacIcon" x:Shared="False"
           Style="{StaticResource UacIconStyle}"
+          Width="16" Height="16"/>
+
+    <Style x:Key="PrimaryUacIconStyle" TargetType="{x:Type Image}">
+        <Setter Property="Source" Value="{x:Static utilities:NativeMethods.UacIcon}"/>
+        <Setter Property="Visibility" Value="{Binding Path=CanDoCentralActions, Source={x:Static app:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
+    </Style>
+
+    <Image x:Key="PrimaryUacIcon" x:Shared="False"
+          Style="{StaticResource PrimaryUacIconStyle}"
+          Width="16" Height="16"/>
+
+    <Style x:Key="TertiaryUacIconStyle" TargetType="{x:Type Image}">
+        <Setter Property="Source" Value="{x:Static utilities:NativeMethods.UacIcon}"/>
+        <Setter Property="Visibility" Value="{Binding Path=CanDoTertiaryActions, Source={x:Static app:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
+    </Style>
+
+    <Image x:Key="TertiaryUacIcon" x:Shared="False"
+          Style="{StaticResource TertiaryUacIconStyle}"
           Width="16" Height="16"/>
 
     <system:Double x:Key="ToggleSwitchFontSize">15</system:Double>
@@ -649,10 +665,10 @@
     <ContextMenu x:Key="PackagesContextMenu"
                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
                  d:DataContext="{d:DesignInstance Type=items:PackageViewModel}">
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuInstall}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuInstall}" Icon="{StaticResource PrimaryUacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"
                   Command="{commands:DataContextCommandAdapter Install}" />
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuPin}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuPin}" Icon="{StaticResource TertiaryUacIcon}"
                   Command="{commands:DataContextCommandAdapter Pin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -661,7 +677,7 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUnpin}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUnpin}" Icon="{StaticResource TertiaryUacIcon}"
                   Command="{commands:DataContextCommandAdapter Unpin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -670,13 +686,13 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUninstall}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUninstall}" Icon="{StaticResource PrimaryUacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Uninstall}" />
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuReinstall}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuReinstall}" Icon="{StaticResource PrimaryUacIcon}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Reinstall}" />
-        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUpdate}" Icon="{StaticResource UacIcon}"
+        <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuUpdate}" Icon="{StaticResource PrimaryUacIcon}"
                   Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Update}" />
         <MenuItem Header="{x:Static lang:Resources.Controls_PackagesContextMenuDetails}" Command="{commands:DataContextCommandAdapter ViewDetails}" />

--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -95,6 +95,11 @@ namespace ChocolateyGui.Services
         public async Task InstallPackage(string id, SemanticVersion version = null, Uri source = null, bool force = false)
         {
             await Initialize(true);
+            if (Elevation.Instance.IsBackgroundRunning)
+            {
+                source = null;
+            }
+
             var result = await _chocolateyService.InstallPackage(id, version?.ToString(), source, force);
             if (!result.Successful)
             {
@@ -145,6 +150,11 @@ namespace ChocolateyGui.Services
         public async Task UpdatePackage(string id, Uri source = null)
         {
             await Initialize(true);
+            if (Elevation.Instance.IsBackgroundRunning)
+            {
+                source = null;
+            }
+
             var result = await _chocolateyService.UpdatePackage(id, source);
             if (!result.Successful)
             {
@@ -226,6 +236,10 @@ namespace ChocolateyGui.Services
         {
             await Initialize(true);
             await _chocolateyService.SetFeature(feature);
+            if (string.Equals(feature.Name, "useBackgroundService", StringComparison.OrdinalIgnoreCase))
+            {
+                Elevation.Instance.IsBackgroundRunning = feature.Enabled;
+            }
         }
 
         public async Task<IReadOnlyList<ChocolateySetting>> GetSettings()
@@ -380,7 +394,7 @@ namespace ChocolateyGui.Services
                 _chocolateyService = CreateClient();
 
                 // ReSharper disable once PossibleNullReferenceException
-                ((ElevationStatusProvider)Application.Current.FindResource("Elevation")).IsElevated = await _chocolateyService.IsElevated();
+                Elevation.Instance.IsElevated = await _chocolateyService.IsElevated();
             }
         }
 

--- a/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyRemotePackageService.cs
@@ -40,7 +40,7 @@ namespace ChocolateyGui.Services
 
         private Process _chocolateyProcess;
         private IIpcChocolateyService _chocolateyService;
-        private bool? _requiresElevation;
+        private bool? _canBeElevated;
 
         public ChocolateyRemotePackageService(
             IProgressService progressService,
@@ -61,12 +61,12 @@ namespace ChocolateyGui.Services
             await Initialize();
             var results = await _chocolateyService.Search(query, options);
             return new PackageSearchResults
-                       {
-                           Packages =
+            {
+                Packages =
                                results.Packages.Select(
                                    pcgke => _mapper.Map(pcgke, _packageFactory())),
-                           TotalCount = results.TotalCount
-                       };
+                TotalCount = results.TotalCount
+            };
         }
 
         public async Task<IPackageViewModel> GetByVersionAndIdAsync(string id, SemanticVersion version, bool isPrerelease)
@@ -278,9 +278,9 @@ namespace ChocolateyGui.Services
             return await _chocolateyService.RemoveSource(id);
         }
 
-        public ValueTask<bool> RequiresElevation()
+        public ValueTask<bool> CanBeElevated()
         {
-            return _requiresElevation.HasValue ? new ValueTask<bool>(_requiresElevation.Value) : new ValueTask<bool>(RequiresElevationImpl());
+            return _canBeElevated.HasValue ? new ValueTask<bool>(_canBeElevated.Value) : new ValueTask<bool>(CanBeElevatedImpl());
         }
 
         public void Dispose()
@@ -294,11 +294,15 @@ namespace ChocolateyGui.Services
             }
         }
 
-        private async Task<bool> RequiresElevationImpl()
+        private async Task<bool> CanBeElevatedImpl()
         {
-            await Initialize();
-            _requiresElevation = !await _chocolateyService.IsElevated();
-            return _requiresElevation.Value;
+            if (_chocolateyProcess == null || _chocolateyProcess.HasExited)
+            {
+                await Initialize();
+            }
+
+            _canBeElevated = !Elevation.Instance.IsBackgroundRunning && !await _chocolateyService.IsElevated();
+            return _canBeElevated.Value;
         }
 
         private async Task Initialize(bool requireAdmin = false)
@@ -321,7 +325,7 @@ namespace ChocolateyGui.Services
             // Check if we're not already initialized or running, as well as our permissions level.
             if (_chocolateyProcess != null && !_chocolateyProcess.HasExited)
             {
-                if (!requireAdmin || await _chocolateyService.IsElevated())
+                if (!requireAdmin || !await CanBeElevated())
                 {
                     return;
                 }
@@ -332,7 +336,7 @@ namespace ChocolateyGui.Services
                 // Double check our initialization and permissions status.
                 if (_chocolateyProcess != null && !_chocolateyProcess.HasExited)
                 {
-                    if (!requireAdmin || await _chocolateyService.IsElevated())
+                    if (!requireAdmin || !await CanBeElevated())
                     {
                         return;
                     }
@@ -395,6 +399,7 @@ namespace ChocolateyGui.Services
 
                 // ReSharper disable once PossibleNullReferenceException
                 Elevation.Instance.IsElevated = await _chocolateyService.IsElevated();
+                _canBeElevated = !Elevation.Instance.IsBackgroundRunning && !Elevation.Instance.IsElevated;
             }
         }
 

--- a/Source/ChocolateyGui/Services/IChocolateyPackageService.cs
+++ b/Source/ChocolateyGui/Services/IChocolateyPackageService.cs
@@ -38,7 +38,7 @@ namespace ChocolateyGui.Services
 
         Task SetFeature(ChocolateyFeature feature);
 
-        ValueTask<bool> RequiresElevation();
+        ValueTask<bool> CanBeElevated();
 
         Task<IReadOnlyList<ChocolateySetting>> GetSettings();
 

--- a/Source/ChocolateyGui/Startup/ChocolateyGuiModule.cs
+++ b/Source/ChocolateyGui/Startup/ChocolateyGuiModule.cs
@@ -31,6 +31,7 @@ namespace ChocolateyGui.Startup
 
             // Register Providers
             builder.RegisterType<VersionNumberProvider>().As<IVersionNumberProvider>().SingleInstance();
+            builder.RegisterType<Elevation>().SingleInstance();
 
             var configurationProvider = new ChocolateyConfigurationProvider();
             builder.RegisterInstance(configurationProvider).As<IChocolateyConfigurationProvider>().SingleInstance();

--- a/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
@@ -20,6 +20,7 @@ using ChocolateyGui.Services;
 using ChocolateyGui.Utilities.Extensions;
 using ChocolateyGui.ViewModels.Items;
 using Serilog;
+using ChocolateyGui.Base;
 
 namespace ChocolateyGui.ViewModels
 {
@@ -304,6 +305,10 @@ namespace ChocolateyGui.ViewModels
                 {
                     await _eventAggregator.PublishOnUIThreadAsync(new PackageHasUpdateMessage(update.Item1, update.Item2));
                 }
+            }
+            catch (ConnectionClosedException)
+            {
+                Logger.Warning("Threw connection closed message while processing load packages.");
             }
             catch (Exception ex)
             {

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -19,7 +19,13 @@
         <converters:NullToVisibility x:Key="NullToVisibility" />
         <converters:LongSizeToFileSizeString x:Key="LongSizeToFileSizeString" />
         <converters:PackageDependenciesToString x:Key="PackageDependenciesToString" />
-        <Style x:Key="UacActionStyle" BasedOn="{StaticResource UacIconStyle}" TargetType="Image">
+        <Style x:Key="PrimaryUacActionStyle" BasedOn="{StaticResource PrimaryUacIconStyle}" TargetType="Image">
+            <Setter Property="Width" Value="16"/>
+            <Setter Property="Height" Value="16"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0 0 5 0"/>
+        </Style>
+        <Style x:Key="TertiaryUacActionStyle" BasedOn="{StaticResource TertiaryUacIconStyle}" TargetType="Image">
             <Setter Property="Width" Value="16"/>
             <Setter Property="Height" Value="16"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
@@ -64,7 +70,7 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Install}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Install" Margin="0 0 5 0 " VerticalAlignment="Center" />
 																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonInstall}" FontSize="16"/>
                             </StackPanel>
@@ -76,7 +82,7 @@
                                 Command="{commands:DataContextCommandAdapter Pin}"
                                 Visibility="{Binding IsPinned, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="Pin" Margin="0 0 5 0 " VerticalAlignment="Center" />
 																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonPin}" FontSize="16"/>
                             </StackPanel>
@@ -85,7 +91,7 @@
                                 Command="{commands:DataContextCommandAdapter Unpin}"
                                 Visibility="{Binding IsPinned, Converter={StaticResource BooleanToVisibility}}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="PinRemove" Margin="0 0 5 0 " VerticalAlignment="Center" />
 																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUnpin}" FontSize="16"/>
                             </StackPanel>
@@ -93,7 +99,7 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Reinstall}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cw" Margin="0 0 5 0 " VerticalAlignment="Center" />
 																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonReinstall}" FontSize="16"/>
                             </StackPanel>
@@ -101,7 +107,7 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Uninstall}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Uninstall" Margin="0 0 5 0 " VerticalAlignment="Center" />
 								<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUninstall}" FontSize="16"/>
                             </StackPanel>
@@ -110,7 +116,7 @@
                             Command="{commands:DataContextCommandAdapter Update}"
                             Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource UacActionStyle}" />
+                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cycle" Margin="0 0 5 0 " VerticalAlignment="Center" />
 																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUpdate}" FontSize="16"/>
                             </StackPanel>

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -72,7 +72,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Install" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonInstall}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonInstall}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -84,7 +84,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="Pin" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonPin}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonPin}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                         <Button Padding="10" Margin="5 0"
@@ -93,7 +93,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="PinRemove" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUnpin}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUnpin}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                         <Button Padding="10" Margin="5 0"
@@ -101,7 +101,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cw" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonReinstall}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonReinstall}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                         <Button Padding="10" Margin="5 0"
@@ -109,7 +109,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Uninstall" Margin="0 0 5 0 " VerticalAlignment="Center" />
-								<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUninstall}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUninstall}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                         <Button Padding="10" Margin="5 0"
@@ -118,7 +118,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cycle" Margin="0 0 5 0 " VerticalAlignment="Center" />
-																<TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUpdate}" FontSize="16"/>
+                                <TextBlock Text="{x:Static lang:Resources.PackageView_ButtonUpdate}" FontSize="16"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -127,18 +127,18 @@
         </Grid>
 
         <StackPanel DockPanel.Dock="Left" Margin="20,0,0,0">
-						<Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_Downloads}"
+            <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_Downloads}"
                    Target="{Binding ElementName=VersionDownloadCount}" />
             <TextBlock x:Name="VersionDownloadCount" Text="{Binding VersionDownloadCount, StringFormat=N0}"
                        Style="{StaticResource PackageResourceValue}" />
-						<Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_TotalDownloads}"
+            <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_TotalDownloads}"
                    Target="{Binding ElementName=DownloadCount}" />
             <TextBlock x:Name="DownloadCount" Text="{Binding DownloadCount, StringFormat=N0}"
                        Style="{StaticResource PackageResourceValue}" />
-						<Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_LastUpdate}"
+            <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_LastUpdate}"
                    Target="{Binding ElementName=Published}" />
             <TextBlock x:Name="Published" Text="{Binding Published, StringFormat=g}" Style="{StaticResource PackageResourceValue}" />
-						<Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_PackageSize}"
+            <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_PackageSize}"
                    Target="{Binding ElementName=PackageSize}" />
             <TextBlock x:Name="PackageSize"
                        Text="{Binding PackageSize, Converter={StaticResource LongSizeToFileSizeString}}"
@@ -191,17 +191,17 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="3*" />
             </Grid.RowDefinitions>
-						<TextBlock Grid.Row="0" Text="{x:Static lang:Resources.PackageView_PackageID}" Style="{StaticResource SectionHeaderTextStyle}"
+            <TextBlock Grid.Row="0" Text="{x:Static lang:Resources.PackageView_PackageID}" Style="{StaticResource SectionHeaderTextStyle}"
                        Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
             <TextBlock Grid.Row="1" Text="{Binding Id}" ScrollViewer.CanContentScroll="True" TextWrapping="Wrap"
                        Style="{StaticResource PageTextBlockStyle}"
                        Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
-						<TextBlock Grid.Row="2" Text="{x:Static lang:Resources.PackageView_Summary}" Style="{StaticResource SectionHeaderTextStyle}"
+            <TextBlock Grid.Row="2" Text="{x:Static lang:Resources.PackageView_Summary}" Style="{StaticResource SectionHeaderTextStyle}"
                        Visibility="{Binding Summary, Converter={StaticResource NullToVisibility}}" />
             <TextBlock Grid.Row="3" Text="{Binding Summary}" ScrollViewer.CanContentScroll="True" TextWrapping="Wrap"
                        Style="{StaticResource PageTextBlockStyle}"
                        Visibility="{Binding Summary, Converter={StaticResource NullToVisibility}}" />
-						<TextBlock Grid.Row="4" Text="{x:Static lang:Resources.PackageView_Description}" Style="{StaticResource SectionHeaderTextStyle}" />
+            <TextBlock Grid.Row="4" Text="{x:Static lang:Resources.PackageView_Description}" Style="{StaticResource SectionHeaderTextStyle}" />
             <controls:MarkdownViewer 
                 AutomationProperties.Name="Package Description"
                 Grid.Row="5"
@@ -210,12 +210,12 @@
                 Margin="5 0"
                 MarkdownString="{Binding Description}" />
             <StackPanel Grid.Row="6" Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
-								<TextBlock Text="{x:Static lang:Resources.PackageView_Dependencies}" Style="{StaticResource SectionHeaderTextStyle}" />
+                <TextBlock Text="{x:Static lang:Resources.PackageView_Dependencies}" Style="{StaticResource SectionHeaderTextStyle}" />
                 <TextBlock Text="{Binding Dependencies, Converter={StaticResource PackageDependenciesToString}}"
                            Margin="5" Style="{StaticResource PageTextBlockStyle}"
                            AutomationProperties.Name="Package Dependencies" />
             </StackPanel>
-						<TextBlock Grid.Row="7" Text="{x:Static lang:Resources.PackageView_ReleaseNotes}" Style="{StaticResource SectionHeaderTextStyle}"
+            <TextBlock Grid.Row="7" Text="{x:Static lang:Resources.PackageView_ReleaseNotes}" Style="{StaticResource SectionHeaderTextStyle}"
                        Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}" />
             <controls:MarkdownViewer Grid.Row="8"
                                       AutomationProperties.Name="Package Release Notes"

--- a/Source/ChocolateyGui/Views/SettingsView.xaml
+++ b/Source/ChocolateyGui/Views/SettingsView.xaml
@@ -53,9 +53,9 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="2*"/>
                         </Grid.ColumnDefinitions>
-												<TextBlock Grid.ColumnSpan="2" Margin="10 5 10 3" Style="{StaticResource SubheaderTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_SubheaderChoco}"/>
+                        <TextBlock Grid.ColumnSpan="2" Margin="10 5 10 3" Style="{StaticResource SubheaderTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_SubheaderChoco}"/>
                         <DockPanel Margin="10 0 5 0" Grid.Column="0" Grid.Row="1">
-														<TextBlock DockPanel.Dock="Top" Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Features}"/>
+                            <TextBlock DockPanel.Dock="Top" Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Features}"/>
                             <ScrollViewer>
                                 <ItemsControl ItemsSource="{Binding Features}">
                                     <ItemsControl.ItemTemplate>
@@ -75,22 +75,22 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-														<TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Settings}"/>
+                            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Settings}"/>
                             <DataGrid Grid.Row="1" BorderBrush="#DDD" BorderThickness="1 1 1 0"
                                       CanUserAddRows="False" CanUserDeleteRows="False" 
                                       ItemsSource="{Binding Settings}" AutoGenerateColumns="False"
                                       cal:Message.Attach="[Event RowEditEnding] = [Action RowEditEnding($eventArgs)]">
                                 <DataGrid.Columns>
-																		<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyName}" Width="*" IsReadOnly="True" Binding="{Binding Key}"/>
-																		<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyValue}" Width="2*" Binding="{Binding Value}"/>
-																		<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyDescription}" Width="2*" IsReadOnly="True" Binding="{Binding Description}"/>
+                                    <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyName}" Width="*" IsReadOnly="True" Binding="{Binding Key}"/>
+                                    <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyValue}" Width="2*" Binding="{Binding Value}"/>
+                                    <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_PropertyDescription}" Width="2*" IsReadOnly="True" Binding="{Binding Description}"/>
                                 </DataGrid.Columns>
                             </DataGrid>
                         </Grid>
                     </Grid>
                 </Grid>
             </TabItem>
-						<TabItem Header="{x:Static lang:Resources.SettingsView_Sources}">
+            <TabItem Header="{x:Static lang:Resources.SettingsView_Sources}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -99,31 +99,34 @@
                     </Grid.RowDefinitions>
 
                     <!-- Sources -->
-										<TextBlock Grid.Row="0" Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Sources}"/>
+                    <TextBlock Grid.Row="0" Style="{StaticResource TitleTextBlockStyle}" Text="{x:Static lang:Resources.SettingsView_Sources}"/>
                     <DataGrid  x:Name="SourcesGrid"
                                Grid.Row="1" Grid.Column="0"
                                CanUserAddRows="False" CanUserDeleteRows="False" IsReadOnly="True"
                                cal:Message.Attach="[Event SelectionChanged] = [Action SourceSelectionChanged(SourcesGrid.SelectedItem)]"
                                ItemsSource="{Binding Sources}" AutoGenerateColumns="False">
                         <DataGrid.Columns>
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesId}" Width="*" Binding="{Binding Id}"/>
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesPath}" Width="3*" Binding="{Binding Value}"/>
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesUsername}" Width="*" Binding="{Binding UserName}" />
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesPassword}" Width="*" Binding="{Binding Password}" />
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificate}" Width="*" Binding="{Binding Certificate}" />
-														<DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificatePass}" Width="*" Binding="{Binding CertificatePassword}" />
-														<metro:DataGridNumericUpDownColumn Header="{x:Static lang:Resources.SettingsView_SourcesPriority}" Binding="{Binding Priority}"/>
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesId}" Width="*" Binding="{Binding Id}"/>
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesPath}" Width="3*" Binding="{Binding Value}"/>
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesUsername}" Width="*" Binding="{Binding UserName}" />
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesPassword}" Width="*" Binding="{Binding Password}" />
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificate}" Width="*" Binding="{Binding Certificate}" />
+                            <DataGridTextColumn Header="{x:Static lang:Resources.SettingsView_SourcesCertificatePass}" Width="*" Binding="{Binding CertificatePassword}" />
+                            <metro:DataGridNumericUpDownColumn Header="{x:Static lang:Resources.SettingsView_SourcesPriority}" Binding="{Binding Priority}"/>
                             <DataGridCheckBoxColumn Header="{x:Static lang:Resources.SettingsView_SourcesDisabled}" Width="Auto" Binding="{Binding Disabled}"/>
+                            <DataGridCheckBoxColumn Header="{x:Static lang:Resources.SettingsView_SourcesByPassProxy}" Width="Auto" Binding="{Binding ByPassProxy}"/>
+                            <DataGridCheckBoxColumn Header="{x:Static lang:Resources.SettingsView_SourcesSelfService}" Width="Auto" Binding="{Binding SelfService}"/>
                         </DataGrid.Columns>
                     </DataGrid>
                     <DockPanel Grid.Row="2" Grid.Column="0" Margin="5">
                         <Grid DockPanel.Dock="Top">
                             <TextBlock Text="Source" Margin="15 5 0 0" Style="{StaticResource SubtitleTextBlockStyle}"/>
-														<Button x:Name="New" HorizontalAlignment="Right" VerticalAlignment="Center" Width="80" Padding="5" Content="{x:Static lang:Resources.SettingsView_ButtonNew}"/>
+                            <Button x:Name="New" HorizontalAlignment="Right" VerticalAlignment="Center" Width="80" Padding="5" Content="{x:Static lang:Resources.SettingsView_ButtonNew}"/>
                         </Grid>
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="35"/>
                                 <RowDefinition Height="35"/>
                                 <RowDefinition Height="35"/>
                                 <RowDefinition Height="35"/>
@@ -157,35 +160,43 @@
                                 </Style>
                             </Grid.Resources>
 
-														<TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesId}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesId}"/>
                             <TextBox Grid.Row="1" Grid.Column="1" VerticalContentAlignment="Center" Text="{Binding SelectedSource.Id}"/>
 
-														<TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesSource}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesSource}"/>
                             <TextBox Grid.Row="2" Grid.Column="1"
                                  VerticalContentAlignment="Center"  Text="{Binding SelectedSource.Value}"/>
 
-														<TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesUsername}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesUsername}"/>
                             <TextBox Grid.Row="3" Grid.Column="1" VerticalContentAlignment="Center"  Text="{Binding SelectedSource.UserName}"/>
 
-														<TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesPassword}"/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesPassword}"/>
                             <TextBox Grid.Row="4" Grid.Column="1"
                                  VerticalContentAlignment="Center"  Text="{Binding SelectedSource.Password}"/>
 
-														<TextBlock Grid.Row="1" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesCertificate}"/>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static lang:Resources.SettingsView_SourcesPriority}"/>
+                            <metro:NumericUpDown Grid.Row="5" Grid.Column="1" VerticalContentAlignment="Center" Value="{Binding SelectedSource.Priority}"/>
+                            
+                            <TextBlock Grid.Row="1" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesCertificate}"/>
                             <TextBox Grid.Row="1" Grid.Column="3" VerticalContentAlignment="Center"  Text="{Binding SelectedSource.Certificate}"/>
 
-														<TextBlock Grid.Row="2" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesCertificatePass}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesCertificatePass}"/>
                             <TextBox Grid.Row="2" Grid.Column="3"
                                  VerticalContentAlignment="Center"  Text="{Binding SelectedSource.CertificatePassword}"/>
 
-														<TextBlock Grid.Row="3" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesIsDisabled}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesIsDisabled}"/>
                             <CheckBox Grid.Row="3" Grid.Column="3"
                                  VerticalAlignment="Center" IsChecked="{Binding SelectedSource.Disabled}"/>
 
-														<TextBlock Grid.Row="4" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesPriority}"/>
-                            <metro:NumericUpDown Grid.Row="4" Grid.Column="3" VerticalContentAlignment="Center" Value="{Binding SelectedSource.Priority}"/>
+                            <TextBlock Grid.Row="4" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesIsByPassProxy}"/>
+                            <CheckBox Grid.Row="4" Grid.Column="3"
+                                 VerticalAlignment="Center" IsChecked="{Binding SelectedSource.ByPassProxy}"/>
 
-                            <StackPanel Grid.Row="5" Grid.Column="3"  Orientation="Horizontal" Margin="15 0 0 0">
+                            <TextBlock Grid.Row="5" Grid.Column="2" Text="{x:Static lang:Resources.SettingsView_SourcesIsSelfService}"/>
+                            <CheckBox Grid.Row="5" Grid.Column="3"
+                                 VerticalAlignment="Center" IsChecked="{Binding SelectedSource.SelfService}"/>
+
+                            <StackPanel Grid.Row="6" Grid.Column="3"  Orientation="Horizontal" Margin="15 0 0 0">
                                 <Button x:Name="Save"
                                 Padding="5 5" Margin="5 0" Width="80"
                                 HorizontalAlignment="Left" VerticalAlignment="Center" Content="{x:Static lang:Resources.SettingsView_ButtonSave}"/>
@@ -202,7 +213,7 @@
                     </DockPanel>
                 </Grid>
             </TabItem>
-						<TabItem Header="{x:Static lang:Resources.SettingsView_About}">
+            <TabItem Header="{x:Static lang:Resources.SettingsView_About}">
                 <Grid Background="White">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -223,7 +234,7 @@
                             HorizontalAlignment="Stretch"
                             Margin="5 0"
                             MarkdownSource="pack://application:,,,/../../Resources/ABOUT.md" />
-										<TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SectionHeaderTextStyle}" Text="{x:Static lang:Resources.SettingsView_Credits}"/>
+                    <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource SectionHeaderTextStyle}" Text="{x:Static lang:Resources.SettingsView_Credits}"/>
                     <controls:MarkdownViewer 
                             AutomationProperties.Name="Credits"
                             Grid.Row="3" Grid.Column="0"
@@ -232,7 +243,7 @@
                             Margin="5 0"
                             MarkdownSource="pack://application:,,,/../../Resources/CREDITS.md" />
 
-										<TextBlock Grid.Row="0" Grid.Column="1" Style="{StaticResource SectionHeaderTextStyle}" Text="{x:Static lang:Resources.SettingsView_ReleaseNotes}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Style="{StaticResource SectionHeaderTextStyle}" Text="{x:Static lang:Resources.SettingsView_ReleaseNotes}"/>
                     <controls:MarkdownViewer 
                             AutomationProperties.Name="Release Notes"
                             Grid.Row="1" Grid.Column="1" Grid.RowSpan="3"

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -10,7 +10,7 @@
   <package id="CefSharp.Common" version="57.0.0" targetFramework="net452" />
   <package id="CefSharp.OffScreen" version="57.0.0" targetFramework="net452" />
   <package id="CefSharp.Wpf" version="57.0.0" targetFramework="net452" />
-  <package id="chocolatey.lib" version="0.10.6.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="0.10.7" targetFramework="net452" />
   <package id="LiteDB" version="3.1.0" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="MahApps.Metro" version="1.5.0" targetFramework="net452" />


### PR DESCRIPTION
When using self-service installs, a feature in Chocolatey for Business,
it provides a background agent that actually performs the
installations. Chocolatey itself handles passing through the proper
information to the background service so that installations can occur.
The GUI should notice the feature is switched on and adjust to allow
non-administrators to run certain commands in the GUI without
attempting to elevate.

Supersedes #382
Closes #371