### PR TITLE
Make Local Grid Single Select and more intelligently filter Packages

### DIFF
--- a/Source/ChocolateyGui/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyService.cs
@@ -6,10 +6,6 @@
 
 namespace ChocolateyGui.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
     using AutoMapper;
     using chocolatey;
     using chocolatey.infrastructure.app;
@@ -22,6 +18,10 @@ namespace ChocolateyGui.Services
     using Microsoft.VisualStudio.Threading;
     using Models;
     using NuGet;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
     using ChocolateySource = Models.ChocolateySource;
     using ILogger = Serilog.ILogger;
 
@@ -63,7 +63,7 @@ namespace ChocolateyGui.Services
             }
         }
 
-        public async Task<IReadOnlyList<Tuple<string, SemanticVersion>>> GetOutdatedPackages(bool includePrerelease = false)
+        public async Task<IReadOnlyList<Tuple<string, SemanticVersion>>> GetOutdatedPackages(bool includePrerelease = false, string packageName = null)
         {
             using (await Lock.ReadLockAsync())
             {
@@ -72,7 +72,7 @@ namespace ChocolateyGui.Services
                     config =>
                         {
                             config.CommandName = "outdated";
-                            config.PackageNames = ApplicationParameters.AllPackages;
+                            config.PackageNames = packageName ?? ApplicationParameters.AllPackages;
                             config.UpgradeCommand.NotifyOnlyAvailableUpgrades = true;
                             config.RegularOutput = false;
                             config.QuietOutput = true;

--- a/Source/ChocolateyGui/Services/IChocolateyService.cs
+++ b/Source/ChocolateyGui/Services/IChocolateyService.cs
@@ -4,14 +4,14 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using ChocolateyGui.Models;
 using System;
 using System.Threading.Tasks;
-using ChocolateyGui.Models;
 
 namespace ChocolateyGui.Services
 {
-    using System.Collections.Generic;
     using NuGet;
+    using System.Collections.Generic;
 
     public interface IChocolateyService
     {
@@ -19,7 +19,7 @@ namespace ChocolateyGui.Services
 
         Task<IEnumerable<Package>> GetInstalledPackages();
 
-        Task<IReadOnlyList<Tuple<string, SemanticVersion>>> GetOutdatedPackages(bool includePrerelease = false);
+        Task<IReadOnlyList<Tuple<string, SemanticVersion>>> GetOutdatedPackages(bool includePrerelease = false, string packageName = null);
 
         Task<PackageResults> Search(string query, PackageSearchOptions options);
 

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -4,9 +4,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
 using AutoMapper;
 using Caliburn.Micro;
 using ChocolateyGui.Base;
@@ -14,6 +11,9 @@ using ChocolateyGui.Models.Messages;
 using ChocolateyGui.Properties;
 using ChocolateyGui.Services;
 using NuGet;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Action = System.Action;
 using MemoryCache = System.Runtime.Caching.MemoryCache;
 
@@ -25,7 +25,6 @@ namespace ChocolateyGui.ViewModels.Items
     public class PackageViewModel :
         ObservableBase,
         IPackageViewModel,
-        IHandleWithTask<PackageChangedMessage>,
         IHandle<PackageHasUpdateMessage>
     {
         private static readonly Serilog.ILogger Logger = Serilog.Log.ForContext<PackageViewModel>();
@@ -355,6 +354,7 @@ namespace ChocolateyGui.ViewModels.Items
                         return;
                     }
 
+                    IsInstalled = true;
                     _eventAggregator.BeginPublishOnUIThread(new PackageChangedMessage(Id, PackageChangeType.Installed, Version));
                 }
             }
@@ -418,6 +418,7 @@ namespace ChocolateyGui.ViewModels.Items
                         return;
                     }
 
+                    IsInstalled = false;
                     _eventAggregator.BeginPublishOnUIThread(new PackageChangedMessage(Id, PackageChangeType.Uninstalled, Version));
                 }
             }
@@ -503,6 +504,7 @@ namespace ChocolateyGui.ViewModels.Items
                         return;
                     }
 
+                    IsPinned = true;
                     _eventAggregator.BeginPublishOnUIThread(new PackageChangedMessage(Id, PackageChangeType.Pinned, Version));
                 }
             }
@@ -546,6 +548,7 @@ namespace ChocolateyGui.ViewModels.Items
                         return;
                     }
 
+                    IsPinned = false;
                     _eventAggregator.BeginPublishOnUIThread(new PackageChangedMessage(Id, PackageChangeType.Unpinned, Version));
                 }
             }
@@ -569,37 +572,6 @@ namespace ChocolateyGui.ViewModels.Items
             }
 
             await _eventAggregator.PublishOnUIThreadAsync(new ShowPackageDetailsMessage(this)).ConfigureAwait(false);
-        }
-
-        public Task Handle(PackageChangedMessage message)
-        {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            if (message.Id != Id)
-            {
-                return Task.FromResult(true);
-            }
-
-            switch (message.ChangeType)
-            {
-                case PackageChangeType.Installed:
-                    IsInstalled = true;
-                    break;
-                case PackageChangeType.Uninstalled:
-                    IsInstalled = false;
-                    break;
-                case PackageChangeType.Pinned:
-                    IsPinned = true;
-                    break;
-                case PackageChangeType.Unpinned:
-                    IsPinned = false;
-                    break;
-            }
-
-            return Task.FromResult(true);
         }
 
         public void Handle(PackageHasUpdateMessage message)

--- a/Source/ChocolateyGui/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui/Views/LocalSourceView.xaml
@@ -42,8 +42,8 @@
             <Button Command="{commands:DataContextCommandAdapter ExportAll, CanExportAll}"
                     Style="{StaticResource SquareButtonStyle}" Margin="4,0,0,0" Content="{x:Static lang:Resources.LocalSourceView_ButtonExport}" />
         </StackPanel>
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Packages}" Background="{StaticResource ControlBackgroundBrush}"
-                  AutoGenerateColumns="False" IsReadOnly="True"
+        <DataGrid Grid.Row="1" ItemsSource="{Binding PackageSource}" Background="{StaticResource ControlBackgroundBrush}"
+                  AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single"
                   MouseDoubleClick="PackageDoubleClick" Style="{DynamicResource PackagesGridStyle}">
             <DataGrid.Columns>
                 <DataGridTemplateColumn Header="{x:Static lang:Resources.LocalSourceView_Grid_Name}" Width="2*">
@@ -62,7 +62,7 @@
                 <DataGridTextColumn Header="{x:Static lang:Resources.LocalSourceView_Grid_LatestVersion}" Binding="{Binding LatestVersion, IsAsync=True}" Width="1*" />
             </DataGrid.Columns>
         </DataGrid>
-        <controls:ProgressRing Grid.Row="1" IsActive="{Binding FirstLoadComplete}"/>
+        <controls:ProgressRing Grid.Row="1" IsActive="{Binding FirstLoadIncomplete}"/>
         <ProgressBar Grid.Row="1" Height="10" VerticalAlignment="Bottom" IsIndeterminate="True" x:Name="PART_Loading"
                      Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibility}}"/>
     </Grid>


### PR DESCRIPTION
Makes the data grid for the Local Source package view single select. We don't support bulk operations (currently).

Replaces buggy filter and package update code with an ICollectionView which handles filtering, and improve package self-operation behavior.

Resolves #463, #462, #421.

Built on top of #466 changes.