### PR TITLE
(GH-478) Fix German texts in settings page are to long

### DIFF
--- a/Source/ChocolateyGui/Views/SettingsView.xaml
+++ b/Source/ChocolateyGui/Views/SettingsView.xaml
@@ -123,7 +123,7 @@
                             <TextBlock Text="Source" Margin="15 5 0 0" Style="{StaticResource SubtitleTextBlockStyle}"/>
                             <Button x:Name="New" HorizontalAlignment="Right" VerticalAlignment="Center" Width="80" Padding="5" Content="{x:Static lang:Resources.SettingsView_ButtonNew}"/>
                         </Grid>
-                        <Grid>
+                        <Grid Grid.IsSharedSizeScope="True">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="35"/>
@@ -133,11 +133,11 @@
                                 <RowDefinition Height="38"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="150"/>
+                                <ColumnDefinition MinWidth="100" SharedSizeGroup="LabelColumn1" />
                                 <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition MinWidth="100" SharedSizeGroup="LabelColumn1" />
                                 <ColumnDefinition Width="1*"/>
-                                <ColumnDefinition Width="180"/>
+                                <ColumnDefinition MinWidth="100" SharedSizeGroup="LabelColumn2" />
                                 <ColumnDefinition Width="1*"/>
                             </Grid.ColumnDefinitions>
 


### PR DESCRIPTION
Use `Grid.IsSharedSizeScope` and `SharedSizeGroup` for columns, so every language should now show it's labels.

![2017-10-06_10h11_06](https://user-images.githubusercontent.com/658431/31269256-fb8a50b6-aa7f-11e7-9948-796e96201e8b.png)

Fixes #478 