### PR TITLE
(GH-452) Support SxS Packages

### DIFF
--- a/Source/ChocolateyGui/Base/ObservableBase.cs
+++ b/Source/ChocolateyGui/Base/ObservableBase.cs
@@ -14,15 +14,16 @@ namespace ChocolateyGui.Base
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public void SetPropertyValue<T>(ref T property, T value, [CallerMemberName] string propertyName = "")
+        public bool SetPropertyValue<T>(ref T property, T value, [CallerMemberName] string propertyName = "")
         {
             if (EqualityComparer<T>.Default.Equals(property, value))
             {
-                return;
+                return false;
             }
 
             property = value;
             NotifyPropertyChanged(propertyName);
+            return true;
         }
 
         public void NotifyPropertyChanged(string propertyName)

--- a/Source/ChocolateyGui/ChocolateyExtensions.cs
+++ b/Source/ChocolateyGui/ChocolateyExtensions.cs
@@ -6,20 +6,14 @@
 
 namespace ChocolateyGui
 {
-    using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using chocolatey;
     using chocolatey.infrastructure.results;
 
     public static class ChocolateyExtensions
     {
-        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _cancellationTokenSources =
-            new ConcurrentDictionary<string, CancellationTokenSource>(StringComparer.OrdinalIgnoreCase);
-
         public static Task RunAsync(this GetChocolatey chocolatey)
         {
             return Task.Run(() => chocolatey.Run());

--- a/Source/ChocolateyGui/Models/Package.cs
+++ b/Source/ChocolateyGui/Models/Package.cs
@@ -33,6 +33,8 @@ namespace ChocolateyGui.Models
 
         public bool IsPinned { get; set; }
 
+        public bool IsSideBySide { get; set; }
+
         public bool IsLatestVersion { get; set; }
 
         public bool IsPrerelease { get; set; }

--- a/Source/ChocolateyGui/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyService.cs
@@ -465,6 +465,7 @@ namespace ChocolateyGui.Services
                 var packageInfo = packageInfoService.get_package_information(package.Package);
                 mappedPackage.IsPinned = packageInfo.IsPinned;
                 mappedPackage.IsInstalled = !string.IsNullOrWhiteSpace(package.InstallLocation) || forceInstalled;
+                mappedPackage.IsSideBySide = packageInfo.IsSideBySide;
             }
 
             return mappedPackage;

--- a/Source/ChocolateyGui/ViewModels/Items/IPackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/IPackageViewModel.cs
@@ -36,6 +36,8 @@ namespace ChocolateyGui.ViewModels.Items
 
         bool IsPinned { get; set; }
 
+        bool IsSideBySide { get; set; }
+
         bool IsLatestVersion { get; set; }
 
         bool IsPrerelease { get; set; }

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -59,6 +59,7 @@ namespace ChocolateyGui.ViewModels.Items
         private bool _isInstalled;
 
         private bool _isPinned;
+        private bool _isSideBySide;
 
         private bool _isLatestVersion;
 
@@ -133,7 +134,7 @@ namespace ChocolateyGui.ViewModels.Items
             set { SetPropertyValue(ref _authors, value); }
         }
 
-        public bool CanUpdate => IsInstalled && !IsPinned && LatestVersion != null && LatestVersion > Version;
+        public bool CanUpdate => IsInstalled && !IsPinned && !IsSideBySide && LatestVersion != null && LatestVersion > Version;
 
         public string Copyright
         {
@@ -198,8 +199,26 @@ namespace ChocolateyGui.ViewModels.Items
 
             set
             {
-                SetPropertyValue(ref _isPinned, value);
-                NotifyPropertyChanged(nameof(CanUpdate));
+                if (SetPropertyValue(ref _isPinned, value))
+                {
+                    NotifyPropertyChanged(nameof(CanUpdate));
+                }
+            }
+        }
+ 
+        public bool IsSideBySide
+        {
+            get
+            {
+                return _isSideBySide;
+            }
+
+            set
+            {
+                if (SetPropertyValue(ref _isSideBySide, value))
+                {
+                    NotifyPropertyChanged(nameof(CanUpdate));
+                }
             }
         }
 

--- a/Source/ChocolateyGui/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui/Views/LocalSourceView.xaml
@@ -50,7 +50,8 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="{x:Type items:IPackageViewModel}">
                             <StackPanel Orientation="Horizontal">
-                                <iconPacks:PackIconEntypo Kind="Pin" Visibility="{Binding IsPinned, Converter={StaticResource BoolToHidden}}" />
+                                <iconPacks:PackIconEntypo ToolTip="Pinned" Kind="Pin" Visibility="{Binding IsPinned, Converter={StaticResource BoolToHidden}}" />
+                                <iconPacks:PackIconEntypo ToolTip="Installed Side by Side with another version of the same package." Kind="Bookmarks" Visibility="{Binding IsSideBySide, Converter={StaticResource BoolToHidden}}" />
                                 <TextBlock Text="{Binding Title}"/>
                             </StackPanel>
                         </DataTemplate>


### PR DESCRIPTION
Adds an indicator icon forSxS installed packages. Forbids SxS packges from being updated. Also adds tooltips to SxS and Pinned icons.

Removes some dead code in Chocolatey Extensions, and adds a helpful tweak to Observable's Base 