### PR TITLE
(build) Fix sign criteria for null paths

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -32,7 +32,7 @@ var CERT_ALGORITHM = EnvironmentVariable("CERT_ALGORITHM") ?? "Sha256";
 // So for now, we will just look to sign the executables prior to building MSI
 Task("SignExecutable")
     .WithCriteria(() => {
-       return FileExists(CERT_PATH);
+       return !string.IsNullOrWhiteSpace(CERT_PATH) && FileExists(CERT_PATH);
     })
     .Does(() =>
     {
@@ -108,7 +108,7 @@ Task("BuildMSI")
 Task("SignMSI")
     .IsDependentOn("BuildMSI")
     .WithCriteria(() => {
-       return FileExists(CERT_PATH);
+       return !string.IsNullOrWhiteSpace(CERT_PATH) && FileExists(CERT_PATH);
     })
     .Does(() =>
     {


### PR DESCRIPTION
There was a thought that FileExists was robust enough to handle nulls
or empty strings and return false (because of course a null file
doesn't exist), but it appears that it simply does no validation and
allows the null value check against File.Exists, which errors on
missing paths. Check to be sure the value is empty prior to sending it
to the helper method.