### PR TITLE
(GH-509) Fix remote source view overlays and improve UI

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -77,6 +77,9 @@
     <Reference Include="MahApps.Metro.IconPacks.Entypo, Version=1.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.IconPacks.Entypo.1.9.1\lib\net45\MahApps.Metro.IconPacks.Entypo.dll</HintPath>
     </Reference>
+    <Reference Include="MahApps.Metro.IconPacks.FontAwesome, Version=1.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MahApps.Metro.IconPacks.FontAwesome.1.9.1\lib\net45\MahApps.Metro.IconPacks.FontAwesome.dll</HintPath>
+    </Reference>
     <Reference Include="MahApps.Metro.IconPacks.Modern, Version=1.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.IconPacks.Modern.1.9.1\lib\net45\MahApps.Metro.IconPacks.Modern.dll</HintPath>
     </Reference>

--- a/Source/ChocolateyGui/Resources/ControlStyles/SourceList.xaml
+++ b/Source/ChocolateyGui/Resources/ControlStyles/SourceList.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Style TargetType="StackPanel" x:Key="LeftSourceListItem">
+    <Style TargetType="Panel" x:Key="LeftSourceListItem">
         <Style.Resources>
             <Style TargetType="TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource IdealForegroundColorBrush}" />

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -481,7 +481,7 @@
     </Style>
 
     <Style x:Key="PageCountTextStyle" TargetType="{x:Type TextBlock}">
-        <Setter Property="Foreground" Value="{StaticResource AccentColorBrush4}" />
+        <Setter Property="Foreground" Value="{StaticResource IdealForegroundColorBrush}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="FontSize" Value="14" />
     </Style>

--- a/Source/ChocolateyGui/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui/Views/RemoteSourceView.xaml
@@ -6,8 +6,6 @@
              xmlns:commands="clr-namespace:ChocolateyGui.Commands"
              xmlns:viewModels="clr-namespace:ChocolateyGui.ViewModels"
              xmlns:items="clr-namespace:ChocolateyGui.ViewModels.Items"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-             xmlns:cal="http://www.caliburnproject.org"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:lang="clr-namespace:ChocolateyGui.Properties"
              mc:Ignorable="d"
@@ -20,7 +18,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,5"
+        <StackPanel Orientation="Horizontal" Margin="0,5"
                     Style="{StaticResource LeftSourceListItem}">
             <Label Margin="5,0" FontSize="16" FontWeight="SemiBold" Target="{Binding ElementName=SearchTextBox}" Content="{x:Static lang:Resources.RemoteSourceView_SearchBoxText}"/>
             <TextBox x:Name="SearchTextBox" Width="200" Padding="0,2,0,-2" FontSize="14"
@@ -38,7 +36,7 @@
                     Style="{StaticResource SquareButtonStyle}" Content="{x:Static lang:Resources.RemoteSourceView_ButtonRefreshPkgs}" Margin="0,4,0,4" />
         </StackPanel>
 
-        <Grid Grid.Row="2" DockPanel.Dock="Bottom" Margin="4">
+        <Grid Grid.Row="2" Margin="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
@@ -63,31 +61,32 @@
                     Style="{DynamicResource PaginationButtonStyle}"/>
         </Grid>
 
-        <ListBox Grid.Row="1" x:Name="Packages" ItemsSource="{Binding Packages}"
+        <ListBox Grid.Row="1" x:Name="Packages" ItemsSource="{Binding Packages, Mode=OneWay}"
+                 Style="{StaticResource VirtualisedMetroListBox}"
                  VerticalAlignment="Stretch"
                  HorizontalContentAlignment="Stretch"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                  MouseDoubleClick="Packages_OnMouseDoubleClick">
+            <ListBox.Resources>
+                <Style x:Key="ColoredDetailsText" TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="{StaticResource AccentBaseColorBrush}"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
+                            <Setter Property="Foreground" Value="White"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+                <Style x:Key="ColoredDetailsTextLine" TargetType="Run">
+                    <Setter Property="Foreground" Value="{StaticResource AccentBaseColorBrush}"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
+                            <Setter Property="Foreground" Value="White"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ListBox.Resources>
             <ListBox.ItemTemplate>
                 <DataTemplate DataType="items:IPackageViewModel">
-                    <DataTemplate.Resources>
-                        <Style x:Key="ColoredDetailsText" TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="{StaticResource AccentBaseColorBrush}"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
-                                    <Setter Property="Foreground" Value="White"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                        <Style x:Key="ColoredDetailsTextLine" TargetType="Run">
-                            <Setter Property="Foreground" Value="{StaticResource AccentBaseColorBrush}"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
-                                    <Setter Property="Foreground" Value="White"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </DataTemplate.Resources>
                     <Grid x:Name="PackageDetailsGrid" Height="105" Margin="5" HorizontalAlignment="Stretch" Background="Transparent"
                           ContextMenu="{StaticResource PackagesContextMenu}">
                         <Grid.RowDefinitions>
@@ -95,52 +94,54 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
+
                         <Grid x:Name="PART_Top" Grid.Row="0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock x:Name="Title" Style="{StaticResource ColoredDetailsText}" FontSize="26" Text="{Binding Title}"/>
-                                <TextBlock x:Name="Version" Margin="5 0 0 0" Style="{StaticResource ColoredDetailsText}" FontSize="26" Text="{Binding Version}"/>
-                            </StackPanel>
-                            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+                            <TextBlock x:Name="TitleVersion" Grid.Row="0" Grid.Column="0"
+                                       TextTrimming="CharacterEllipsis"
+                                       Style="{StaticResource ColoredDetailsText}" FontSize="26">
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="{}{0} {1}">
+                                        <Binding Path="Title" Mode="OneWay" />
+                                        <Binding Path="Version" Mode="OneWay" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
+                            <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
                                 <TextBlock FontSize="14"
-                                           AutomationProperties.Name="{Binding Authors, Converter={StaticResource StringListToString}}"
-                                           IsHitTestVisible="false">
+                                           AutomationProperties.Name="{Binding Authors, Mode=OneWay, Converter={StaticResource StringListToString}}"
+                                           IsHitTestVisible="False">
                                     <Run Text="{x:Static lang:Resources.RemoteSourceView_Authors}" />
-                                    <Run Style="{StaticResource ColoredDetailsTextLine}" Text="{Binding Authors, Converter={StaticResource StringListToString}}" />
+                                    <Run Style="{StaticResource ColoredDetailsTextLine}" Text="{Binding Authors, Mode=OneWay, Converter={StaticResource StringListToString}}" />
                                 </TextBlock>
                             </StackPanel>
-                            <TextBlock Grid.Row="0"
-                                       Grid.Column="1" Grid.RowSpan="2"
-                                       FontWeight="SemiBold"
-                                       FontSize="20"
-                                       HorizontalAlignment="Right"
-                                       IsHitTestVisible="false">
-                                <Run Text="{Binding DownloadCount, StringFormat=N0}"/>
-                                <Run Text="{x:Static lang:Resources.RemoteSourceView_Downloads}"/>
-                            </TextBlock>
+                            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" IsHitTestVisible="False">
+                                <TextBlock FontWeight="SemiBold" FontSize="20" Text="{Binding DownloadCount, Mode=OneWay, StringFormat=N0}" Style="{StaticResource ColoredDetailsText}" VerticalAlignment="Center" />
+                                <iconPacks:PackIconFontAwesome Kind="Download" Width="16" Height="16" Margin="5 1 0 0" VerticalAlignment="Center" />
+                            </StackPanel>
                         </Grid>
+
                         <Grid x:Name="PART_Body" Grid.Row="1">
-                            <TextBlock TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Text="{Binding Description}"/>
+                            <TextBlock TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Text="{Binding Description, Mode=OneWay}"/>
                         </Grid>
+                        
                         <Grid x:Name="PART_Bottom" Grid.Row="2">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <StackPanel Orientation="Horizontal">
+                            <StackPanel Grid.Column="0" Orientation="Horizontal">
                                 <TextBlock x:Name="TagsLabel" FontSize="14">Tags:</TextBlock>
-                                <TextBlock x:Name="Tags" Margin="5 0 0 0" Style="{StaticResource ColoredDetailsText}" FontSize="14" Text="{Binding Tags}"></TextBlock>
+                                <TextBlock x:Name="Tags" Margin="5 0 0 0" Style="{StaticResource ColoredDetailsText}" TextTrimming="CharacterEllipsis" FontSize="14" Text="{Binding Tags, Mode=OneWay}" />
                             </StackPanel>
-                            <StackPanel Grid.Column="1" Orientation="Horizontal" FlowDirection="RightToLeft">
-                                <iconPacks:PackIconEntypo Kind="Check" Width="15" Height="15" Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}" />
-                            </StackPanel>
+                            <iconPacks:PackIconEntypo Grid.Column="1" Kind="Check" Width="16" Height="16" VerticalAlignment="Center" Visibility="{Binding IsInstalled, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}" />
                         </Grid>
                     </Grid>
                 </DataTemplate>

--- a/Source/ChocolateyGui/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui/Views/RemoteSourceView.xaml
@@ -51,8 +51,15 @@
                     Command="{commands:DataContextCommandAdapter Executed=GoToPrevious, CanExecute=CanGoToPrevious}"
                     Style="{DynamicResource PaginationButtonStyle}"/>
             <TextBlock Grid.Column="2" Name="CurrentPage" AutomationProperties.Name="Current Page"
-                       HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding CurrentPage}"
-                       Style="{StaticResource PageCountTextStyle}"/>
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Style="{StaticResource PageCountTextStyle}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0} / {1}">
+                        <Binding Path="CurrentPage" Mode="OneWay" />
+                        <Binding Path="PageCount" Mode="OneWay" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
             <Button Grid.Column="3" Name="ForwardPage" Content="{x:Static lang:Resources.RemoteSourceView_ButtonGoForwardAPage}" AutomationProperties.Name="Go Forward a Page" ToolTip="Forward"
                     Command="{commands:DataContextCommandAdapter Executed=GoToNext, CanExecute=CanGoToNext}"
                     Style="{DynamicResource PaginationButtonStyle}"/>

--- a/Source/ChocolateyGui/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui/Views/RemoteSourceView.xaml
@@ -76,14 +76,6 @@
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
-                <Style x:Key="ColoredDetailsTextLine" TargetType="Run">
-                    <Setter Property="Foreground" Value="{StaticResource AccentBaseColorBrush}"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
-                            <Setter Property="Foreground" Value="White"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
             </ListBox.Resources>
             <ListBox.ItemTemplate>
                 <DataTemplate DataType="items:IPackageViewModel">

--- a/Source/ChocolateyGui/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui/Views/RemoteSourceView.xaml
@@ -114,13 +114,12 @@
                                     </MultiBinding>
                                 </TextBlock.Text>
                             </TextBlock>
-                            <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
-                                <TextBlock FontSize="14"
+                            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" IsHitTestVisible="False">
+                                <TextBlock FontSize="14" Text="{x:Static lang:Resources.RemoteSourceView_Authors}" />
+                                <TextBlock FontSize="14" Margin="5 0 0 0" Text="{Binding Authors, Mode=OneWay, Converter={StaticResource StringListToString}}"
+                                           TextTrimming="CharacterEllipsis"
                                            AutomationProperties.Name="{Binding Authors, Mode=OneWay, Converter={StaticResource StringListToString}}"
-                                           IsHitTestVisible="False">
-                                    <Run Text="{x:Static lang:Resources.RemoteSourceView_Authors}" />
-                                    <Run Style="{StaticResource ColoredDetailsTextLine}" Text="{Binding Authors, Mode=OneWay, Converter={StaticResource StringListToString}}" />
-                                </TextBlock>
+                                           Style="{StaticResource ColoredDetailsText}" />
                             </StackPanel>
                             <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" IsHitTestVisible="False">
                                 <TextBlock FontWeight="SemiBold" FontSize="20" Text="{Binding DownloadCount, Mode=OneWay, StringFormat=N0}" Style="{StaticResource ColoredDetailsText}" VerticalAlignment="Center" />
@@ -137,9 +136,13 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                <TextBlock x:Name="TagsLabel" FontSize="14">Tags:</TextBlock>
-                                <TextBlock x:Name="Tags" Margin="5 0 0 0" Style="{StaticResource ColoredDetailsText}" TextTrimming="CharacterEllipsis" FontSize="14" Text="{Binding Tags, Mode=OneWay}" />
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" IsHitTestVisible="False">
+                                <!-- TODO add lang:Resource for this -->
+                                <TextBlock x:Name="TagsLabel" FontSize="14" Text="Tags:" />
+                                <TextBlock x:Name="Tags" FontSize="14" Margin="5 0 0 0" Text="{Binding Tags, Mode=OneWay}"
+                                           TextTrimming="CharacterEllipsis"
+                                           AutomationProperties.Name="{Binding Tags, Mode=OneWay, Converter={StaticResource StringListToString}}"
+                                           Style="{StaticResource ColoredDetailsText}" />
                             </StackPanel>
                             <iconPacks:PackIconEntypo Grid.Column="1" Kind="Check" Width="16" Height="16" VerticalAlignment="Center" Visibility="{Binding IsInstalled, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}" />
                         </Grid>

--- a/Source/ChocolateyGui/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui/Views/RemoteSourceView.xaml
@@ -8,6 +8,7 @@
              xmlns:items="clr-namespace:ChocolateyGui.ViewModels.Items"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:lang="clr-namespace:ChocolateyGui.Properties"
+             xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d"
              d:DesignHeight="768" d:DesignWidth="1366"
              d:DataContext="{d:DesignInstance viewModels:RemoteSourceViewModel}">
@@ -18,31 +19,43 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Margin="0,5"
-                    Style="{StaticResource LeftSourceListItem}">
-            <Label Margin="5,0" FontSize="16" FontWeight="SemiBold" Target="{Binding ElementName=SearchTextBox}" Content="{x:Static lang:Resources.RemoteSourceView_SearchBoxText}"/>
-            <TextBox x:Name="SearchTextBox" Width="200" Padding="0,2,0,-2" FontSize="14"
-                     Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}" />
-            <CheckBox Name="AllVersionsCheckBox" Margin="10,5,5,5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxAllVersions}"
-                      IsChecked="{Binding IncludeAllVersions}" />
-            <CheckBox Name="PrereleaseCheckBox" Margin="5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxIncludePrerelease}"
-                      IsChecked="{Binding IncludePrerelease}" />
-            <CheckBox Name="MatchCheckBox" Margin="5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxMatchExactly}" IsChecked="{Binding MatchWord}" />
-            <ComboBox Name="SortBox" Margin="5" ItemsSource="{Binding SortOptions}" SelectedValue="{Binding SortSelection}"/>
-        </StackPanel>
-        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center"
-                    Margin="10,5">
-            <Button Command="{commands:DataContextCommandAdapter RefreshRemotePackages, CanRefreshRemotePackages}"
-                    Style="{StaticResource SquareButtonStyle}" Content="{x:Static lang:Resources.RemoteSourceView_ButtonRefreshPkgs}" Margin="0,4,0,4" />
-        </StackPanel>
 
-        <Grid Grid.Row="2" Margin="4">
+        <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <WrapPanel Grid.Column="0" Orientation="Horizontal" Margin="0,5" Style="{StaticResource LeftSourceListItem}">
+                <StackPanel Orientation="Horizontal" Margin="0 0 5 0">
+                    <Label Margin="5,0" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" Target="{Binding ElementName=SearchTextBox}" Content="{x:Static lang:Resources.RemoteSourceView_SearchBoxText}"/>
+                    <TextBox x:Name="SearchTextBox" Width="200" FontSize="14"
+                     VerticalContentAlignment="Center"
+                     controls:TextBoxHelper.Watermark="{x:Static lang:Resources.RemoteSourceView_SearchBoxText}"
+                     Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+                <CheckBox Name="AllVersionsCheckBox" Margin="5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxAllVersions}"
+                      IsChecked="{Binding IncludeAllVersions}" />
+                <CheckBox Name="PrereleaseCheckBox" Margin="5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxIncludePrerelease}"
+                      IsChecked="{Binding IncludePrerelease}" />
+                <CheckBox Name="MatchCheckBox" Margin="5" Content="{x:Static lang:Resources.RemoteSourceView_CheckboxMatchExactly}" IsChecked="{Binding MatchWord}" />
+                <ComboBox Name="SortBox" Margin="5" ItemsSource="{Binding SortOptions}" SelectedValue="{Binding SortSelection}"/>
+            </WrapPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Margin="10,5">
+                <Button Command="{commands:DataContextCommandAdapter RefreshRemotePackages, CanRefreshRemotePackages}"
+                    Style="{StaticResource SquareButtonStyle}" ToolTip="{x:Static lang:Resources.RemoteSourceView_ButtonRefreshPkgs}" Margin="0,4,0,4">
+                    <iconPacks:PackIconFontAwesome Kind="Refresh" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="4" Grid.IsSharedSizeScope="True">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
                 <ColumnDefinition Width="3*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
             </Grid.ColumnDefinitions>
             <Button Grid.Column="0" Name="FirstPage" Content="{x:Static lang:Resources.RemoteSourceView_ButtonGotoFirstPage}" AutomationProperties.Name="Go to First Page" ToolTip="First"
                     Command="{commands:DataContextCommandAdapter Executed=GoToFirst, CanExecute=CanGoToFirst}"

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -13,6 +13,7 @@
   <package id="Magick.NET-Q16-x86" version="7.0.7.700" targetFramework="net452" />
   <package id="MahApps.Metro" version="1.5.0" targetFramework="net452" />
   <package id="MahApps.Metro.IconPacks.Entypo" version="1.9.1" targetFramework="net452" />
+  <package id="MahApps.Metro.IconPacks.FontAwesome" version="1.9.1" targetFramework="net452" />
   <package id="MahApps.Metro.IconPacks.Modern" version="1.9.1" targetFramework="net452" />
   <package id="MahApps.Metro.Resources" version="0.6.1.0" targetFramework="net452" />
   <package id="Markdig" version="0.13.3" targetFramework="net452" />


### PR DESCRIPTION
So here my changes suggestions to fix the #509 issue

- `downloads` text replaced with `PackIconFontAwesome` Download icon
- title with version, authors and tags uses now `TextTrimming="CharacterEllipsis"`
- Performance: don't use Runs inside a TextBlock and remove unnecessary ColoredDetailsTextLine style
- show CurrentPage / PageCount on bottom and use IdealForegroundBrush for this
- Use WrapPanel for the header
- Use `PackIconFontAwesome` Refresh icon for the refresh button (tooltip shows now the text)
- make bottom buttons shared size

![2017-10-26_00h34_29](https://user-images.githubusercontent.com/658431/32026746-dfd105f2-b9e5-11e7-9eb4-e0b2e86925a4.png)

![2017-10-26_00h35_08](https://user-images.githubusercontent.com/658431/32026749-e27262c4-b9e5-11e7-94f8-7930cd91224a.png)

![2017-10-26_11h05_51](https://user-images.githubusercontent.com/658431/32044882-11791a14-ba3f-11e7-8ee2-3803424f9e19.png)

![2017-10-26_11h06_06](https://user-images.githubusercontent.com/658431/32044883-134412f4-ba3f-11e7-87d5-48df76333a35.png)

Closes #509 