### PR TITLE
GH501: Fix Package description space

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Models\EnumToBoolConverter.cs" />
     <Compile Include="Models\LogLevel.cs" />
     <Compile Include="Models\LogMessage.cs" />
+    <Compile Include="Utilities\Converters\NullToValue.cs" />
     <Compile Include="Utilities\PackageAuthorsComparer.cs" />
     <Compile Include="Services\ChocolateyService.cs" />
     <Compile Include="Controls\InternetImage.xaml.cs">
@@ -278,7 +279,6 @@
     <Compile Include="Utilities\Converters\LongSizeToFileSizeString.cs" />
     <Compile Include="Utilities\Converters\NullToVisibility.cs" />
     <Compile Include="Utilities\Converters\PackageDependenciesToString.cs" />
-    <Compile Include="Utilities\Converters\UriToVisibility.cs" />
     <Compile Include="Utilities\NativeMethods.cs" />
     <Page Include="Controls\Dialogs\ChocolateyDialog.xaml">
       <SubType>Designer</SubType>

--- a/Source/ChocolateyGui/Utilities/Converters/NullToValue.cs
+++ b/Source/ChocolateyGui/Utilities/Converters/NullToValue.cs
@@ -1,33 +1,32 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright company="Chocolatey" file="UriToVisibility.cs">
+// <copyright company="Chocolatey" file="NullToValue.cs">
 //   Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;
-using System.Windows;
 using System.Windows.Data;
 
 namespace ChocolateyGui.Utilities.Converters
 {
-    public class UriToVisibility : IValueConverter
+    public class NullToValue : IValueConverter
     {
+        public object TrueValue { get; set; }
+
+        public object FalseValue { get; set; }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null || (value is string && string.IsNullOrWhiteSpace((string)value)))
             {
-                return Visibility.Collapsed;
+                return TrueValue;
             }
 
-            return Visibility.Visible;
+            return FalseValue;
         }
 
-        public object ConvertBack(
-            object value,
-            Type targetType,
-            object parameter,
-            CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/Source/ChocolateyGui/Utilities/Converters/NullToVisibility.cs
+++ b/Source/ChocolateyGui/Utilities/Converters/NullToVisibility.cs
@@ -4,28 +4,16 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.Globalization;
 using System.Windows;
-using System.Windows.Data;
 
 namespace ChocolateyGui.Utilities.Converters
 {
-    public class NullToVisibility : IValueConverter
+    public class NullToVisibility : NullToValue
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public NullToVisibility()
         {
-            if (value is string)
-            {
-                return string.IsNullOrWhiteSpace((string)value) ? Visibility.Collapsed : Visibility.Visible;
-            }
-
-            return value == null ? Visibility.Collapsed : Visibility.Visible;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
+            TrueValue = Visibility.Collapsed;
+            FalseValue = Visibility.Visible;
         }
     }
 }

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -18,12 +18,13 @@
     <FrameworkElement.CommandBindings>
         <CommandBinding Command="{x:Static markdig:Commands.Hyperlink}" Executed="HandleMarkdownLink" />
     </FrameworkElement.CommandBindings>
-
     <UserControl.Resources>
-        <converters:UriToVisibility x:Key="UriToVisibilty" />
+        <converters:NullToVisibility x:Key="UriToVisibilty" />
         <converters:NullToVisibility x:Key="NullToVisibility" />
+        <converters:NullToValue x:Key="NullToGridLength" TrueValue="Auto" FalseValue="3*" />
         <converters:LongSizeToFileSizeString x:Key="LongSizeToFileSizeString" />
         <converters:PackageDependenciesToString x:Key="PackageDependenciesToString" />
+
         <Style x:Key="PrimaryUacActionStyle" BasedOn="{StaticResource PrimaryUacIconStyle}" TargetType="Image">
             <Setter Property="Width" Value="16"/>
             <Setter Property="Height" Value="16"/>
@@ -193,12 +194,12 @@
         <Grid Margin="25,5,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="5*" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="3*" />
+                <RowDefinition Height="{Binding ReleaseNotes, Converter={StaticResource NullToGridLength}}" />
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Text="{x:Static lang:Resources.PackageView_PackageID}" Style="{StaticResource SectionHeaderTextStyle}"
                        Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
@@ -206,13 +207,12 @@
                        Style="{StaticResource PageTextBlockStyle}"
                        Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
             <TextBlock Grid.Row="2" Text="{x:Static lang:Resources.PackageView_Description}" Style="{StaticResource SectionHeaderTextStyle}" />
-            <markdig:MarkdownViewer 
-                AutomationProperties.Name="Package Description"
-                Grid.Row="3"
-                VerticalAlignment="Stretch"
-                HorizontalAlignment="Stretch"
-                Margin="5 0"
-                Markdown="{Binding Description}" />
+            <markdig:MarkdownViewer AutomationProperties.Name="Package Description"
+                                    Grid.Row="3"
+                                    VerticalAlignment="Stretch"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="5 0"
+                                    Markdown="{Binding Description}" />
             <StackPanel Grid.Row="4" Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
                 <TextBlock Text="{x:Static lang:Resources.PackageView_Dependencies}" Style="{StaticResource SectionHeaderTextStyle}" />
                 <TextBlock Text="{Binding Dependencies, Converter={StaticResource PackageDependenciesToString}}"
@@ -222,11 +222,11 @@
             <TextBlock Grid.Row="5" Text="{x:Static lang:Resources.PackageView_ReleaseNotes}" Style="{StaticResource SectionHeaderTextStyle}"
                        Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}" />
             <markdig:MarkdownViewer Grid.Row="6"
-                                      AutomationProperties.Name="Package Release Notes"
-                                      VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-                                      Margin="5 0"
-                                      Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}"
-                                      Markdown="{Binding ReleaseNotes}" />
+                                    AutomationProperties.Name="Package Release Notes"
+                                    VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+                                    Margin="5 0"
+                                    Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}"
+                                    Markdown="{Binding ReleaseNotes}" />
 
         </Grid>
     </DockPanel>


### PR DESCRIPTION
This PR fixes the empty space on the package view if there no package release notes given.

**Before**

![image](https://user-images.githubusercontent.com/2190718/31810521-6825b902-b57c-11e7-8fad-dbc38d3ae4f3.png)

**After**

![image](https://user-images.githubusercontent.com/658431/32300546-462b6832-bf5a-11e7-9924-369b9d401180.png)

Closes #501 
