### PR TITLE
(GH-506): Corrected issue with package id

### DIFF
--- a/Source/ChocolateyGui/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyService.cs
@@ -84,7 +84,7 @@ namespace ChocolateyGui.Services
                 var packages = await Task.Run(() => nugetService.upgrade_noop(chocoConfig, null));
                 var results = packages
                     .Where(p => !p.Value.Inconclusive)
-                    .Select(p => Tuple.Create(p.Value.Package.Id, p.Value.Package.Version.ToNormalizedString()))
+                    .Select(p => Tuple.Create(p.Value.Package.Id.ToLower(), p.Value.Package.Version.ToNormalizedString()))
                     .ToArray();
                 var parsed = results.Select(result => Tuple.Create(result.Item1, new SemanticVersion(result.Item2)));
 


### PR DESCRIPTION
In chocolatey when it gets webstorm package:
```IPackage availablePackage = packageManager.SourceRepository.FindPackage(packageName, version, config.Prerelease, allowUnlisted: false);```

It returns package with id ```WebStorm```. But when it gets local package:
```IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);```
 it returns id ```webstorm```.

So there is probably a bug.
And in the fix chocolateyGUI takes packageName instead of id which seems to work.


