### PR TITLE
(GH-431) Added different background for outdated packages.

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Models\EnumToBoolConverter.cs" />
     <Compile Include="Models\LogLevel.cs" />
     <Compile Include="Models\LogMessage.cs" />
+    <Compile Include="Utilities\Converters\BooleanToVisibilityInverted.cs" />
     <Compile Include="Utilities\Converters\NullToValue.cs" />
     <Compile Include="Utilities\PackageAuthorsComparer.cs" />
     <Compile Include="Services\ChocolateyService.cs" />

--- a/Source/ChocolateyGui/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui/Properties/Resources.Designer.cs
@@ -411,9 +411,9 @@ namespace ChocolateyGui.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Out Of Date.
         /// </summary>
-        public static string LocalSourceView_OverlayOutdated {
+        public static string LocalSourceView_Outdated {
             get {
-                return ResourceManager.GetString("LocalSourceView_OverlayOutdated", resourceCulture);
+                return ResourceManager.GetString("LocalSourceView_Outdated", resourceCulture);
             }
         }
         

--- a/Source/ChocolateyGui/Properties/Resources.resx
+++ b/Source/ChocolateyGui/Properties/Resources.resx
@@ -615,7 +615,7 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   <data name="LocalSourceView_ButtonTileView" xml:space="preserve">
     <value>Tile View</value>
   </data>
-  <data name="LocalSourceView_OverlayOutdated" xml:space="preserve">
+  <data name="LocalSourceView_Outdated" xml:space="preserve">
     <value>Out Of Date</value>
   </data>
   <data name="RemoteSourceView_ButtonListView" xml:space="preserve">

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -738,7 +738,7 @@
                     <Setter Property="ContextMenu" Value="{StaticResource PackagesContextMenu}" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding IsLatestVersion}" Value="False">
-                            <Setter Property="Background" Value="#ffffe6"/>
+                            <Setter Property="Background" Value="#FFDBCA"/>
                         </DataTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter Property="Background" Value="{DynamicResource AccentColorBrush}" />

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -21,6 +21,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <converters:BooleanToVisibility x:Key="BooleanToVisibility" />
+    <converters:BooleanToVisibilityInverted x:Key="BooleanToVisibilityInverted" />
     <converters:BooleanToTickString x:Key="BooleanToTickString" />
     <converters:StringListToString x:Key="StringListToString" />
     <converters:BooleanInverter x:Key="BooleanInverter" />
@@ -737,9 +738,6 @@
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="ContextMenu" Value="{StaticResource PackagesContextMenu}" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsLatestVersion}" Value="False">
-                            <Setter Property="Background" Value="#FFDBCA"/>
-                        </DataTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter Property="Background" Value="{DynamicResource AccentColorBrush}" />
                             <Setter Property="Foreground" Value="{DynamicResource AccentSelectedColorBrush}" />

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -53,7 +53,7 @@
           Width="16" Height="16"/>
 
     <system:Double x:Key="ToggleSwitchFontSize">15</system:Double>
-    
+
     <Style x:Key="SourceBaseTextBlockStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="FontFamily" Value="./Resources/#SourceSansPro-Regular" />
         <Setter Property="FontSize" Value="14" />
@@ -737,6 +737,9 @@
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="ContextMenu" Value="{StaticResource PackagesContextMenu}" />
                     <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsLatestVersion}" Value="False">
+                            <Setter Property="Background" Value="#ffffe6"/>
+                        </DataTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter Property="Background" Value="{DynamicResource AccentColorBrush}" />
                             <Setter Property="Foreground" Value="{DynamicResource AccentSelectedColorBrush}" />

--- a/Source/ChocolateyGui/Utilities/Converters/BooleanToVisibilityInverted.cs
+++ b/Source/ChocolateyGui/Utilities/Converters/BooleanToVisibilityInverted.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BooleanToVisibilityInverted.cs" company="Chocolatey">
+// Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ChocolateyGui.Utilities.Converters
+{
+    public class BooleanToVisibilityInverted : DependencyObject, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return IsCollapsed(value, parameter)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static bool IsCollapsed(object value, object parameter)
+        {
+            var boolVal = (value != null && value != DependencyProperty.UnsetValue) && (bool)value;
+            return boolVal == false ^ (parameter != null && bool.Parse((string)parameter));
+        }
+    }
+}

--- a/Source/ChocolateyGui/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui/Views/LocalSourceView.xaml
@@ -21,6 +21,7 @@
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <converters:BooleanToVisibilityInverted x:Key="BoolToVisInverted" />
         <converters:BooleanToVisibilityHidden x:Key="BoolToHidden" />
         <converters:StringListToString x:Key="ListToString" />
 
@@ -63,7 +64,7 @@
                 <ContentControl x:Name="OutOfDateOverlay" ClipToBounds="True" Grid.Row="0" Grid.RowSpan="3" Visibility="Collapsed"
                                 IsTabStop="False"
                                 Focusable="False"
-                                Content="{x:Static lang:Resources.LocalSourceView_OverlayOutdated}"
+                                Content="{x:Static lang:Resources.LocalSourceView_Outdated}"
                                 Background="#A90000"
                                 Foreground="White"
                                 Template="{DynamicResource TileOverlayTemplate}" />
@@ -223,7 +224,30 @@
                                                             utilities:DataGridCustomSortBehavior.CustomComparer="{StaticResource PackageAuthorsComparer}"
                                                             Binding="{Binding Authors, Converter={StaticResource ListToString}}" Width="1*" />
                                         <DataGridTextColumn Header="{x:Static lang:Resources.LocalSourceView_Grid_Version}" Binding="{Binding Version}" Width="1*" />
-                                        <DataGridTextColumn Header="{x:Static lang:Resources.LocalSourceView_Grid_LatestVersion}" Binding="{Binding LatestVersion, IsAsync=True}" Width="1*" />
+                                        <DataGridTemplateColumn Width="0.7*"
+                                                                Header="{x:Static lang:Resources.LocalSourceView_Grid_LatestVersion}">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate DataType="{x:Type items:IPackageViewModel}">
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="0.5*" />
+                                                            <ColumnDefinition Width="0.5*" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBlock Text="{Binding LatestVersion, IsAsync=True}" VerticalAlignment="Center" Grid.Column="0"/>
+                                                        <TextBlock Text="{x:Static lang:Resources.LocalSourceView_Outdated}"
+                                                                   Grid.Column="1"
+                                                                   Background="#A90000"
+                                                                   Foreground="White"
+                                                                   Padding="3"
+                                                                   VerticalAlignment="Center"
+                                                                   HorizontalAlignment="Center"
+                                                                   TextAlignment="Center"
+                                                                   Visibility="{Binding IsLatestVersion, Converter={StaticResource BoolToVisInverted}}"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </DataTemplate>


### PR DESCRIPTION
Related to #431

Any suggestions for the color?
If package is selected or mouse is over the colors should be different or the same as for up to date packages?

![outdatedpackagebackground](https://user-images.githubusercontent.com/25898045/36342048-a9742c38-13f8-11e8-9794-365591083b18.PNG)
