### PR TITLE
(GH-618) Correct issue with ListViewMode default

### DIFF
--- a/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
@@ -64,8 +64,6 @@ namespace ChocolateyGui.ViewModels
             _persistenceService = persistenceService;
             _configService = configService;
 
-            ListViewMode = _configService.GetSettings().DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard;
-
             DisplayName = displayName;
 
             _packages = new List<IPackageViewModel>();
@@ -285,9 +283,16 @@ namespace ChocolateyGui.ViewModels
                     return;
                 }
 
+                ListViewMode = _configService.GetSettings().DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard;
+
                 Observable.FromEventPattern<EventArgs>(_configService, "SettingsChanged")
                     .ObserveOnDispatcher()
-                    .Subscribe(eventPattern => ListViewMode = ((AppConfiguration)eventPattern.Sender).DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard);
+                    .Subscribe(eventPattern =>
+                    {
+                        ListViewMode = ((AppConfiguration) eventPattern.Sender).DefaultToTileViewForLocalSource
+                                ? ListViewMode.Tile
+                                : ListViewMode.Standard;
+                    });
 
                 await LoadPackages();
 

--- a/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/LocalSourceViewModel.cs
@@ -289,7 +289,7 @@ namespace ChocolateyGui.ViewModels
                     .ObserveOnDispatcher()
                     .Subscribe(eventPattern =>
                     {
-                        ListViewMode = ((AppConfiguration) eventPattern.Sender).DefaultToTileViewForLocalSource
+                        ListViewMode = ((AppConfiguration)eventPattern.Sender).DefaultToTileViewForLocalSource
                                 ? ListViewMode.Tile
                                 : ListViewMode.Standard;
                     });

--- a/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/RemoteSourceViewModel.cs
@@ -63,8 +63,6 @@ namespace ChocolateyGui.ViewModels
             _eventAggregator = eventAggregator;
             _mapper = mapper;
 
-            ListViewMode = _configService.GetSettings().DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard;
-
             Packages = new ObservableCollection<IPackageViewModel>();
             DisplayName = source.Id;
 
@@ -284,6 +282,8 @@ namespace ChocolateyGui.ViewModels
         {
             try
             {
+                ListViewMode = _configService.GetSettings().DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard;
+
                 Observable.FromEventPattern<EventArgs>(_configService, "SettingsChanged")
                     .ObserveOnDispatcher()
                     .Subscribe(eventPattern =>


### PR DESCRIPTION
- Due to the fact that ViewModel, which hasn't been initialized, isn't regsitered
to subscribe to SettingChanged event, therefore it didn't "see" the change
- Move default ListViewMode setting into the initialize event to work around
this.