### PR TITLE
(maint) Added Chinese language map

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,6 +1,6 @@
 [main]
 host = https://www.transifex.com
-lang_map = en_GB: en-GB, en_US: en-US
+lang_map = en_GB: en-GB, en_US: en-US, zh_CN: zh-CN
 
 [chocolatey-gui.resourcesresx]
 file_filter = Source/ChocolateyGui/Properties/Resources.<lang>.resx


### PR DESCRIPTION
A new language was added on transifex which uses the full language code, as such
this pr adds a transifex language mapping so the language code would be in the expected format for .NET.
Without this change, the language would be mapped as 'Resources.zh_CN.resx' and possibly make the program crash