### PR TITLE
(GH-506) Fix showing outdated packages

### DIFF
--- a/Source/ChocolateyGui/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui/Services/ChocolateyService.cs
@@ -86,7 +86,7 @@ namespace ChocolateyGui.Services
                 var packages = await Task.Run(() => nugetService.upgrade_noop(chocoConfig, null));
                 var results = packages
                     .Where(p => !p.Value.Inconclusive)
-                    .Select(p => Tuple.Create(p.Value.Package.Id.ToLower(), p.Value.Package.Version.ToNormalizedString()))
+                    .Select(p => Tuple.Create(p.Value.Package.Id, p.Value.Package.Version.ToNormalizedString()))
                     .ToArray();
                 var parsed = results.Select(result => Tuple.Create(result.Item1, new SemanticVersion(result.Item2)));
 

--- a/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/Items/PackageViewModel.cs
@@ -593,7 +593,7 @@ namespace ChocolateyGui.ViewModels.Items
 
         public void Handle(PackageHasUpdateMessage message)
         {
-            if (message.Id != Id)
+            if (!string.Equals(message.Id, Id, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }


### PR DESCRIPTION
Related to #626 #506 #585 

I reverted changes from #557 (calling .ToLower() on package.Id) and changed comparing Ids to case insensitive.
