### PR TITLE
(GH-646) Possibility for separators in the source lists

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -399,6 +399,8 @@
     <Compile Include="ViewModels\Items\IPackageViewModel.cs" />
     <Compile Include="ViewModels\Items\PackageViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />
+    <Compile Include="ViewModels\SourceSeparatorViewModel.cs" />
+    <Compile Include="ViewModels\SourcesListBoxItemStyleSelector.cs" />
     <Compile Include="ViewModels\SourcesViewModel.cs" />
     <Compile Include="ViewModels\PackageViewModel.cs" />
     <Compile Include="ViewModels\RemoteSourceViewModel.cs" />

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -131,6 +131,24 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SourcesSeparatorContainerStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource SourcesListBoxItemContainerStyle}">
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="5,5" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                    <Grid Background="{TemplateBinding Background}" RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}">
+                        <Separator Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
         <Setter Property="Foreground" Value="{DynamicResource IdealForegroundColorBrush}" />
     </Style>

--- a/Source/ChocolateyGui/ViewModels/SourceSeparatorViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SourceSeparatorViewModel.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="SourceSeparatorViewModel.cs">
+//   Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ChocolateyGui.ViewModels
+{
+    public sealed class SourceSeparatorViewModel : ISourceViewModelBase
+    {
+        public string DisplayName
+        {
+            get
+            {
+                return "Separator";
+            }
+        }
+    }
+}

--- a/Source/ChocolateyGui/ViewModels/SourceSeparatorViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SourceSeparatorViewModel.cs
@@ -8,12 +8,13 @@ namespace ChocolateyGui.ViewModels
 {
     public sealed class SourceSeparatorViewModel : ISourceViewModelBase
     {
-        public string DisplayName
+        private const string DISPLAYNAME = "Separator";
+
+        public SourceSeparatorViewModel()
         {
-            get
-            {
-                return "Separator";
-            }
+            DisplayName = DISPLAYNAME;
         }
+
+        public string DisplayName { get; }
     }
 }

--- a/Source/ChocolateyGui/ViewModels/SourcesListBoxItemStyleSelector.cs
+++ b/Source/ChocolateyGui/ViewModels/SourcesListBoxItemStyleSelector.cs
@@ -1,0 +1,32 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="SourcesListBoxItemStyleSelector.cs">
+//   Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ChocolateyGui.ViewModels
+{
+    public sealed class SourcesListBoxItemStyleSelector : StyleSelector
+    {
+        public Style ListBoxItemContainerStyleKey { get; set; }
+
+        public Style SeparatorContainerStyleKey { get; set; }
+
+        public override Style SelectStyle(object item, DependencyObject container)
+        {
+            if (item is SourceSeparatorViewModel && SeparatorContainerStyleKey != null)
+            {
+                return SeparatorContainerStyleKey;
+            }
+            else if (item is ISourceViewModelBase && ListBoxItemContainerStyleKey != null)
+            {
+                return ListBoxItemContainerStyleKey;
+            }
+
+            return base.SelectStyle(item, container);
+        }
+    }
+}

--- a/Source/ChocolateyGui/ViewModels/SourcesViewModel.cs
+++ b/Source/ChocolateyGui/ViewModels/SourcesViewModel.cs
@@ -60,14 +60,15 @@ namespace ChocolateyGui.ViewModels
 
         public async Task LoadSources()
         {
-            var oldItems = Items.Skip(1).Cast<RemoteSourceViewModel>().ToList();
+            var oldItems = Items.Skip(1).Cast<ISourceViewModelBase>().ToList();
 
             var sources = await _packageService.GetSources();
-            var vms = new List<RemoteSourceViewModel>();
+            var vms = new List<ISourceViewModelBase>();
 
             if (_configService.GetSettings().ShowAggregatedSourceView)
             {
                 vms.Add(_remoteSourceVmFactory(new ChocolateyAggregatedSources()));
+                vms.Add(new SourceSeparatorViewModel());
             }
 
             foreach (var source in sources.Where(s => !s.Disabled).OrderBy(s => s.Priority))

--- a/Source/ChocolateyGui/Views/SourcesView.xaml
+++ b/Source/ChocolateyGui/Views/SourcesView.xaml
@@ -18,8 +18,11 @@
                              BorderBrush="Transparent"
                              Padding="5,0,-1,0"
                              Margin="0,100,0,0"
-                             ItemContainerStyle="{DynamicResource SourcesListBoxItemContainerStyle}"
                              SelectedItem="{Binding ActiveItem}">
+                        <ListBox.ItemContainerStyleSelector>
+                            <viewModels:SourcesListBoxItemStyleSelector ListBoxItemContainerStyleKey="{StaticResource SourcesListBoxItemContainerStyle}"
+                                                                        SeparatorContainerStyleKey="{StaticResource SourcesSeparatorContainerStyle}"/>
+                        </ListBox.ItemContainerStyleSelector>
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock x:Name="Tb"


### PR DESCRIPTION
This PR adds a `SourceSeparatorViewModel` class which can be used to show a separator between source items.

![2019-02-18_12h20_01](https://user-images.githubusercontent.com/658431/52950257-d8efc980-337e-11e9-99d9-5b726e684559.png)
