### PR TITLE
(GH-501) Improve UI for Package view

### DIFF
--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -9,7 +9,8 @@
                     xmlns:commands="clr-namespace:ChocolateyGui.Commands"
                     xmlns:utilities="clr-namespace:ChocolateyGui.Utilities"
                     xmlns:app="clr-namespace:ChocolateyGui"
-                    xmlns:lang="clr-namespace:ChocolateyGui.Properties"
+                    xmlns:lang="clr-namespace:ChocolateyGui.Properties" 
+                    xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
                     mc:Ignorable="d">
 
     <ResourceDictionary.MergedDictionaries>
@@ -259,10 +260,20 @@
         <Setter Property="FontSize" Value="22" />
     </Style>
 
-    <Style x:Key="SectionHeaderTextStyle" TargetType="{x:Type TextBlock}">
+    <Style x:Key="SectionHeaderStyle" BasedOn="{StaticResource MahApps.Metro.Styles.MetroHeader}" TargetType="{x:Type Controls:MetroHeader}">
         <Setter Property="Foreground" Value="{StaticResource BodyColorBrush}" />
-        <Setter Property="FontSize" Value="18" />
-        <Setter Property="Margin" Value="3,0,0,3" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="18" />
+        <Setter Property="Padding" Value="10 5 10 5"></Setter>
+        <Setter Property="HeaderTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <StackPanel Orientation="Vertical" UseLayoutRounding="True">
+                        <TextBlock Margin="0 10 0 5" Text="{Binding}" />
+                        <Separator Margin="0 0 5 0"/>
+                    </StackPanel>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="DescriptionTextStyle" TargetType="{x:Type Run}">

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -11,6 +11,7 @@
              xmlns:controls="clr-namespace:ChocolateyGui.Controls"
              xmlns:lang="clr-namespace:ChocolateyGui.Properties"
              xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d"
              d:DesignHeight="786" d:DesignWidth="1366"
              d:DataContext="{d:DesignInstance viewModels:PackageViewModel}">
@@ -198,40 +199,43 @@
         <Grid Margin="25,5,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="5*" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="{Binding ReleaseNotes, Converter={StaticResource NullToGridLength}}" />
             </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0" Text="{x:Static lang:Resources.PackageView_PackageID}" Style="{StaticResource SectionHeaderTextStyle}"
-                       Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
-            <TextBlock Grid.Row="1" Text="{Binding Id}" ScrollViewer.CanContentScroll="True" TextWrapping="Wrap"
-                       Style="{StaticResource PageTextBlockStyle}"
-                       Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}" />
-            <TextBlock Grid.Row="2" Text="{x:Static lang:Resources.PackageView_Description}" Style="{StaticResource SectionHeaderTextStyle}" />
-            <markdig:MarkdownViewer AutomationProperties.Name="Package Description"
-                                    Grid.Row="3"
-                                    VerticalAlignment="Stretch"
-                                    HorizontalAlignment="Stretch"
-                                    Margin="5 0"
-                                    Markdown="{Binding Description}" />
-            <StackPanel Grid.Row="4" Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
-                <TextBlock Text="{x:Static lang:Resources.PackageView_Dependencies}" Style="{StaticResource SectionHeaderTextStyle}" />
+            <mah:MetroHeader Grid.Row="0"
+                             Style="{StaticResource SectionHeaderStyle}"
+                             Header="{x:Static lang:Resources.PackageView_PackageID}"
+                             Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}">
+                <TextBlock Text="{Binding Id}"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource PageTextBlockStyle}" />
+            </mah:MetroHeader>
+            <mah:MetroHeader Grid.Row="1"
+                             Style="{StaticResource SectionHeaderStyle}"
+                             Header="{x:Static lang:Resources.PackageView_Description}">
+                <markdig:MarkdownViewer AutomationProperties.Name="Package Description"
+                                        VerticalAlignment="Stretch"
+                                        HorizontalAlignment="Stretch"
+                                        Markdown="{Binding Description}" />
+            </mah:MetroHeader>
+            <mah:MetroHeader Grid.Row="2"
+                             Style="{StaticResource SectionHeaderStyle}"
+                             Header="{x:Static lang:Resources.PackageView_Dependencies}"
+                             Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
                 <TextBlock Text="{Binding Dependencies, Converter={StaticResource PackageDependenciesToString}}"
-                           Margin="5" Style="{StaticResource PageTextBlockStyle}"
+                           Style="{StaticResource PageTextBlockStyle}"
                            AutomationProperties.Name="Package Dependencies" />
-            </StackPanel>
-            <TextBlock Grid.Row="5" Text="{x:Static lang:Resources.PackageView_ReleaseNotes}" Style="{StaticResource SectionHeaderTextStyle}"
-                       Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}" />
-            <markdig:MarkdownViewer Grid.Row="6"
-                                    AutomationProperties.Name="Package Release Notes"
-                                    VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-                                    Margin="5 0"
-                                    Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}"
-                                    Markdown="{Binding ReleaseNotes}" />
-
+            </mah:MetroHeader>
+            <mah:MetroHeader Grid.Row="3"
+                             Style="{StaticResource SectionHeaderStyle}"
+                             Header="{x:Static lang:Resources.PackageView_ReleaseNotes}"
+                             Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}">
+                <markdig:MarkdownViewer AutomationProperties.Name="Package Release Notes"
+                                        VerticalAlignment="Stretch"
+                                        HorizontalAlignment="Stretch"
+                                        Markdown="{Binding ReleaseNotes}" />
+            </mah:MetroHeader>
         </Grid>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Sometimes the Release notes at the Package view seems like to be empty if there are only one line of text (e.g. #501).

To make this a little bit better I changed the UI to use Separator and increased Margins.

![2019-04-19_23h13_15](https://user-images.githubusercontent.com/658431/56445340-2d6ee100-62fd-11e9-9466-95852c9654b6.png)

![2019-04-19_23h15_31](https://user-images.githubusercontent.com/658431/56445344-3069d180-62fd-11e9-88f4-617f61a9d1ad.png)

Closes #501 
