### PR TITLE
(GH-356) Improve Package view

### DIFF
--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Models\Messages\AboutGoBackMessage.cs" />
     <Compile Include="Models\Messages\ShowAboutMessage.cs" />
     <Compile Include="Utilities\BindingProxy.cs" />
+    <Compile Include="Utilities\BubbleScrollEventBehavior.cs" />
     <Compile Include="Utilities\Converters\BooleanToVisibilityInverted.cs" />
     <Compile Include="Utilities\Converters\NullToValue.cs" />
     <Compile Include="Utilities\PackageAuthorsComparer.cs" />

--- a/Source/ChocolateyGui/Resources/Controls.xaml
+++ b/Source/ChocolateyGui/Resources/Controls.xaml
@@ -297,15 +297,19 @@
     </Style>
 
     <Style x:Key="SectionHeaderStyle" BasedOn="{StaticResource MahApps.Metro.Styles.MetroHeader}" TargetType="{x:Type Controls:MetroHeader}">
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="28" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Foreground" Value="{StaticResource BodyColorBrush}" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="18" />
-        <Setter Property="Padding" Value="10 5 10 5"></Setter>
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="28" />
+        <Setter Property="Padding" Value="2 4" />
+        <Setter Property="Margin" Value="0 0 0 8" />
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
                     <StackPanel Orientation="Vertical" UseLayoutRounding="True">
-                        <TextBlock Margin="0 10 0 5" Text="{Binding}" />
-                        <Separator Margin="0 0 5 0"/>
+                        <TextBlock Margin="0 0 0 4" Text="{Binding}" />
+                        <Separator Margin="0 0 4 0"/>
                     </StackPanel>
                 </DataTemplate>
             </Setter.Value>

--- a/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
+++ b/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
@@ -20,6 +20,7 @@ namespace ChocolateyGui.Utilities
         protected override void OnAttached()
         {
             base.OnAttached();
+
             AssociatedObject.PreviewMouseWheel -= AssociatedObject_PreviewMouseWheel;
             AssociatedObject.PreviewMouseWheel += AssociatedObject_PreviewMouseWheel;
         }
@@ -27,17 +28,22 @@ namespace ChocolateyGui.Utilities
         protected override void OnDetaching()
         {
             AssociatedObject.PreviewMouseWheel -= AssociatedObject_PreviewMouseWheel;
+
             base.OnDetaching();
         }
 
         private void AssociatedObject_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
-            if (!Keyboard.IsKeyDown(Key.LeftShift))
+            var uiElement = sender as UIElement;
+            if (uiElement == null || Keyboard.IsKeyDown(Key.LeftShift))
             {
-                e.Handled = true;
-                var e2 = new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta) { RoutedEvent = UIElement.MouseWheelEvent };
-                AssociatedObject.RaiseEvent(e2);
+                return;
             }
+
+            e.Handled = true;
+
+            var e2 = new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta) { RoutedEvent = UIElement.MouseWheelEvent };
+            uiElement.RaiseEvent(e2);
         }
     }
 }

--- a/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
+++ b/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="BubbleScrollEventBehavior.cs">
+//   Copyright 2014 - Present Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace ChocolateyGui.Utilities
+{
+    /// <summary>
+    /// The BubbleScrollEventBehavior behavior can be used to prevent the mousewheel scrolling on a scrollable control.
+    /// The event will be bubble up to the parent control.
+    /// This behavior can be prevent with the left Shift key.
+    /// </summary>
+    public class BubbleScrollEventBehavior : Behavior<UIElement>
+    {
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            AssociatedObject.PreviewMouseWheel -= AssociatedObject_PreviewMouseWheel;
+            AssociatedObject.PreviewMouseWheel += AssociatedObject_PreviewMouseWheel;
+        }
+
+        protected override void OnDetaching()
+        {
+            AssociatedObject.PreviewMouseWheel -= AssociatedObject_PreviewMouseWheel;
+            base.OnDetaching();
+        }
+
+        private void AssociatedObject_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (!Keyboard.IsKeyDown(Key.LeftShift))
+            {
+                e.Handled = true;
+                var e2 = new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta) { RoutedEvent = UIElement.MouseWheelEvent };
+                AssociatedObject.RaiseEvent(e2);
+            }
+        }
+    }
+}

--- a/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
+++ b/Source/ChocolateyGui/Utilities/BubbleScrollEventBehavior.cs
@@ -32,7 +32,7 @@ namespace ChocolateyGui.Utilities
             base.OnDetaching();
         }
 
-        private void AssociatedObject_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        private static void AssociatedObject_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
             var uiElement = sender as UIElement;
             if (uiElement == null || Keyboard.IsKeyDown(Key.LeftShift))

--- a/Source/ChocolateyGui/Views/PackageView.xaml
+++ b/Source/ChocolateyGui/Views/PackageView.xaml
@@ -12,6 +12,8 @@
              xmlns:lang="clr-namespace:ChocolateyGui.Properties"
              xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:utilities="clr-namespace:ChocolateyGui.Utilities"
              mc:Ignorable="d"
              d:DesignHeight="786" d:DesignWidth="1366"
              d:DataContext="{d:DesignInstance viewModels:PackageViewModel}">
@@ -136,6 +138,18 @@
         </Grid>
 
         <StackPanel DockPanel.Dock="Left" Margin="20,0,0,0">
+            <controls:InternetImage AutomationProperties.Name="Package Icon"
+                                    IconUrl="{Binding IconUrl, IsAsync=True}"
+                                    Width="100" Height="100"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Margin="10" />
+            <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_PackageID}"
+                   Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}"
+                   Target="{Binding ElementName=Id}" />
+            <TextBlock x:Name="Id" Text="{Binding Id}"
+                       Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}"
+                       Style="{StaticResource PackageResourceValue}" />
             <Label Style="{StaticResource PackageResourceLabel}" Content="{x:Static lang:Resources.PackageView_Version}"
                    Target="{Binding ElementName=Version}" />
             <TextBlock x:Name="Version" Text="{Binding Version}"
@@ -192,52 +206,38 @@
 
         </StackPanel>
 
-        <Grid DockPanel.Dock="Right">
-            <controls:InternetImage AutomationProperties.Name="Package Icon" IconUrl="{Binding IconUrl, IsAsync=True}"
-                   Width="100" Height="100" HorizontalAlignment="Center" VerticalAlignment="Top"
-                   Margin="0,0,20,0" />
-        </Grid>
+        <ScrollViewer Margin="25,5,0,0">
+            <StackPanel>
+                <mah:MetroHeader Style="{StaticResource SectionHeaderStyle}"
+                                 Header="{x:Static lang:Resources.PackageView_Description}">
+                    <i:Interaction.Behaviors>
+                        <utilities:BubbleScrollEventBehavior />
+                    </i:Interaction.Behaviors>
+                    <markdig:MarkdownViewer AutomationProperties.Name="Package Description"
+                                            VerticalAlignment="Stretch"
+                                            HorizontalAlignment="Stretch"
+                                            Markdown="{Binding Description}" />
+                </mah:MetroHeader>
 
-        <Grid Margin="25,5,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="5*" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="{Binding ReleaseNotes, Converter={StaticResource NullToGridLength}}" />
-            </Grid.RowDefinitions>
-            <mah:MetroHeader Grid.Row="0"
-                             Style="{StaticResource SectionHeaderStyle}"
-                             Header="{x:Static lang:Resources.PackageView_PackageID}"
-                             Visibility="{Binding Id, Converter={StaticResource NullToVisibility}}">
-                <TextBlock Text="{Binding Id}"
-                           TextWrapping="Wrap"
-                           Style="{StaticResource PageTextBlockStyle}" />
-            </mah:MetroHeader>
-            <mah:MetroHeader Grid.Row="1"
-                             Style="{StaticResource SectionHeaderStyle}"
-                             Header="{x:Static lang:Resources.PackageView_Description}">
-                <markdig:MarkdownViewer AutomationProperties.Name="Package Description"
-                                        VerticalAlignment="Stretch"
-                                        HorizontalAlignment="Stretch"
-                                        Markdown="{Binding Description}" />
-            </mah:MetroHeader>
-            <mah:MetroHeader Grid.Row="2"
-                             Style="{StaticResource SectionHeaderStyle}"
-                             Header="{x:Static lang:Resources.PackageView_Dependencies}"
-                             Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
-                <TextBlock Text="{Binding Dependencies, Converter={StaticResource PackageDependenciesToString}}"
-                           Style="{StaticResource PageTextBlockStyle}"
-                           AutomationProperties.Name="Package Dependencies" />
-            </mah:MetroHeader>
-            <mah:MetroHeader Grid.Row="3"
-                             Style="{StaticResource SectionHeaderStyle}"
-                             Header="{x:Static lang:Resources.PackageView_ReleaseNotes}"
-                             Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}">
-                <markdig:MarkdownViewer AutomationProperties.Name="Package Release Notes"
-                                        VerticalAlignment="Stretch"
-                                        HorizontalAlignment="Stretch"
-                                        Markdown="{Binding ReleaseNotes}" />
-            </mah:MetroHeader>
-        </Grid>
+                <mah:MetroHeader Style="{StaticResource SectionHeaderStyle}"
+                                 Header="{x:Static lang:Resources.PackageView_Dependencies}"
+                                 Visibility="{Binding Dependencies, Converter={StaticResource NullToVisibility}}">
+                    <TextBlock Text="{Binding Dependencies, Converter={StaticResource PackageDependenciesToString}}"
+                               AutomationProperties.Name="Package Dependencies" />
+                </mah:MetroHeader>
+
+                <mah:MetroHeader Style="{StaticResource SectionHeaderStyle}"
+                                 Header="{x:Static lang:Resources.PackageView_ReleaseNotes}"
+                                 Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibility}}">
+                    <i:Interaction.Behaviors>
+                        <utilities:BubbleScrollEventBehavior />
+                    </i:Interaction.Behaviors>
+                    <markdig:MarkdownViewer AutomationProperties.Name="Package Release Notes"
+                                            VerticalAlignment="Stretch"
+                                            HorizontalAlignment="Stretch"
+                                            Markdown="{Binding ReleaseNotes}" />
+                </mah:MetroHeader>
+            </StackPanel>
+        </ScrollViewer>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
The rendering of headings in description are larger then the headings of the Package view.

To improve the Package view the headings outside of the description have now the same font size and weight. Also the Icon and the Id are moved to the left side. The right side is now vertically stretched and can be scrolled if it's to large.

![2019-04-25_23h46_28](https://user-images.githubusercontent.com/658431/56770492-694dee80-67b4-11e9-8fdc-21befce6679b.png)

![2019-04-25_23h46_51](https://user-images.githubusercontent.com/658431/56770495-6b17b200-67b4-11e9-896c-91f931933dd5.png)

![chocopackage](https://user-images.githubusercontent.com/658431/56770507-710d9300-67b4-11e9-8908-a207db4a7aa5.gif)

Closes #356 
