### PR TITLE
(GH-633) Keep aspect ratio for Icons in Tile and Package view

### DIFF
--- a/Source/ChocolateyGui/Controls/InternetImage.xaml.cs
+++ b/Source/ChocolateyGui/Controls/InternetImage.xaml.cs
@@ -89,7 +89,7 @@ namespace ChocolateyGui.Controls
 
         private async Task<IBitmap> LoadImage(string url, float desiredWidth, DateTime absoluteExpiration)
         {
-            var imageStream = await DownloadUrl(url, desiredWidth, absoluteExpiration);
+            var imageStream = await DownloadUrl(url, desiredWidth, absoluteExpiration).ConfigureAwait(false);
 
             // Don't specify width and height to keep the aspect ratio of the image.
             return await BitmapLoader.Current.Load(imageStream, null, null);
@@ -131,11 +131,11 @@ namespace ChocolateyGui.Controls
                     MagickReadSettings readSettings = null;
                     if (string.Equals(extension, "svg", StringComparison.OrdinalIgnoreCase))
                     {
-                        readSettings = new MagickReadSettings() { Format = MagickFormat.Svg };
+                        readSettings = new MagickReadSettings { Format = MagickFormat.Svg };
                     }
                     else if (string.Equals(extension, "svgz", StringComparison.OrdinalIgnoreCase))
                     {
-                        readSettings = new MagickReadSettings() { Format = MagickFormat.Svgz };
+                        readSettings = new MagickReadSettings { Format = MagickFormat.Svgz };
                     }
 
                     using (var image = new MagickImage(memoryStream, readSettings))

--- a/Source/ChocolateyGui/Controls/InternetImage.xaml.cs
+++ b/Source/ChocolateyGui/Controls/InternetImage.xaml.cs
@@ -128,14 +128,21 @@ namespace ChocolateyGui.Controls
                     await response.Content.CopyToAsync(memoryStream);
                     memoryStream.Position = 0;
 
-                    using (var image = new MagickImage(memoryStream))
+                    MagickReadSettings readSettings = null;
+                    if (string.Equals(extension, "svg", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (!string.Equals(extension, "svg", StringComparison.OrdinalIgnoreCase))
-                        {
-                            // Resize the image to the desired width. When zero is specified for the height
-                            // the height will be calculated with the aspect ratio.
-                            image.Resize((int)desiredWidth, 0);
-                        }
+                        readSettings = new MagickReadSettings() { Format = MagickFormat.Svg };
+                    }
+                    else if (string.Equals(extension, "svgz", StringComparison.OrdinalIgnoreCase))
+                    {
+                        readSettings = new MagickReadSettings() { Format = MagickFormat.Svgz };
+                    }
+
+                    using (var image = new MagickImage(memoryStream, readSettings))
+                    {
+                        // Resize the image to the desired width. When zero is specified for the height
+                        // the height will be calculated with the aspect ratio.
+                        image.Resize((int)desiredWidth, 0);
 
                         image.Write(imageStream, MagickFormat.Png);
                         imageStream.Flush();


### PR DESCRIPTION
Keep aspect ratio for Icons in Tile and Package view.

Also make the download of the icons faster by using a memory stream instead a temporary file stream.

**Before**

![2019-04-26_15h15_04](https://user-images.githubusercontent.com/658431/56810413-8a572380-6836-11e9-8cea-dc93be53fda0.png)

![2019-04-26_15h15_39](https://user-images.githubusercontent.com/658431/56810414-8a572380-6836-11e9-8fbe-af0ca4347d13.png)

**After**

![2019-04-26_15h12_40](https://user-images.githubusercontent.com/658431/56810425-904d0480-6836-11e9-9533-a2484b39556f.png)

![2019-04-26_15h12_57](https://user-images.githubusercontent.com/658431/56810426-90e59b00-6836-11e9-9143-1260b03627e3.png)

Closes #633 

/cc @gep13 @mwallner @ferventcoder @pascalberger 