### PR TITLE
Fix broken packageSourceUrl

### DIFF
--- a/nuspec/chocolatey/ChocolateyGUI.nuspec
+++ b/nuspec/chocolatey/ChocolateyGUI.nuspec
@@ -8,7 +8,7 @@
     <owners>Chocolatey</owners>
     <projectUrl>https://github.com/chocolatey/ChocolateyGUI</projectUrl>
     <projectSourceUrl>https://github.com/chocolatey/ChocolateyGUI</projectSourceUrl>
-    <packageSourceUrl>https://github.com/chocolatey/ChocolateyGUI/tree/develop/nuspec/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey/ChocolateyGUI</packageSourceUrl>
     <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/ChocolateyGUI/develop/LICENSE</licenseUrl>
     <bugTrackerUrl>https://github.com/chocolatey/ChocolateyGUI/issues</bugTrackerUrl>


### PR DESCRIPTION
packageSourceUrl points to https://github.com/chocolatey/ChocolateyGUI/tree/develop/nuspec/chocolatey, which does not exist. Changing it to https://github.com/chocolatey/ChocolateyGUI.
Though maybe it should be https://github.com/chocolatey/ChocolateyGUI/tree/develop/nuspec/chocolatey? It's hard to find a spec or recommendations for these values.