### PR TITLE
Pre-fill new issue with template

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,16 @@
+---
+name: Enhancement
+about: In case you want to improve something
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+_(with this PR, I declare that I read the [contributing process](https://github.com/chocolatey/chocolateygui/blob/develop/CONTRIBUTING.md#contributing-process))_
+
+### What do you accomplish with this PR?
+
+
+
+### Why should it be merged?

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,15 @@
+---
+name: Issue
+about: In case you want to report something that is wrong
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Pull Request (PR) pre-requisites**
+
+- [ ] This is not an [enhancement](https://github.com/chocolatey/ChocolateyGUI/blob/develop/CONTRIBUTING.md#submit-pull-request-pr)
+- [ ] I read the [requirements of a PR](https://github.com/chocolatey/ChocolateyGUI#submitting-issues)
+
+### Description of the issue


### PR DESCRIPTION
By convention, GitHub will look for an `issue_template.md` file to pre-fill the new issue page. Right now, the user gets an empty page and has to read PR/Contributing guidelines in at least two files.

With this PR, those instructions can be moved to a template that is displayed automatically to every user that creates an issue.

_Limitations: I don't have enough context to make sure the templates are 100% aligned with your workflow, but at least it's a starting point for your team to later customise ;)_