### PR TITLE
(GH-513) Add keybinding for navigating sources

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Commands\CommandExecutionManager.cs" />
     <Compile Include="Commands\DataContextCommandAdapter.cs" />
     <Compile Include="Commands\DataContextCommandBinding.cs" />
+    <Compile Include="Commands\RelayCommand.cs" />
     <Compile Include="Commands\RoutedCommandBinding.cs" />
     <Compile Include="Commands\RoutedCommandMonitor.cs" />
     <Compile Include="Controls\Dialogs\ChocolateyDialog.xaml.cs">

--- a/Source/ChocolateyGui.Common.Windows/Commands/RelayCommand.cs
+++ b/Source/ChocolateyGui.Common.Windows/Commands/RelayCommand.cs
@@ -21,7 +21,12 @@ namespace ChocolateyGui.Common.Windows.Commands
 
         public RelayCommand(Action<object> execute, Predicate<object> canExecute)
         {
-            _execute = execute ?? throw new ArgumentNullException("execute");
+            if (execute == null)
+            {
+                throw new ArgumentNullException("execute");
+            }
+
+            _execute = execute;
             _canExecute = canExecute;
         }
 

--- a/Source/ChocolateyGui.Common.Windows/Commands/RelayCommand.cs
+++ b/Source/ChocolateyGui.Common.Windows/Commands/RelayCommand.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="RelayCommand.cs">
+//   Copyright 2017 - Present Chocolatey Software, LLC
+//   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System;
+using System.Windows.Input;
+
+namespace ChocolateyGui.Common.Windows.Commands
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action<object> _execute;
+        private readonly Predicate<object> _canExecute;
+
+        public RelayCommand(Action<object> execute)
+            : this(execute, null)
+        {
+        }
+
+        public RelayCommand(Action<object> execute, Predicate<object> canExecute)
+        {
+            _execute = execute ?? throw new ArgumentNullException("execute");
+            _canExecute = canExecute;
+        }
+
+        public RelayCommand()
+        {
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute == null ? true : _canExecute(parameter);
+        }
+
+        public void Execute(object parameter)
+        {
+            _execute(parameter);
+        }
+    }
+}

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/ShellViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/ShellViewModel.cs
@@ -153,14 +153,14 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         private bool CanGoToSource(object obj)
         {
-            return obj is int sourceIndex
-                && sourceIndex > 0
-                && sourceIndex <= _sourcesViewModel.Items.Count;
+            var sourceIndex = obj as int?;
+            return sourceIndex.HasValue && sourceIndex > 0 && sourceIndex <= _sourcesViewModel.Items.Count;
         }
 
         private void GoToSource(object obj)
         {
-            if (obj is int sourceIndex)
+            var sourceIndex = obj as int?;
+            if (sourceIndex.HasValue)
             {
                 --sourceIndex;
 
@@ -169,7 +169,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                     return;
                 }
 
-                _sourcesViewModel.ActivateItem(_sourcesViewModel.Items[sourceIndex]);
+                _sourcesViewModel.ActivateItem(_sourcesViewModel.Items[sourceIndex.Value]);
             }
         }
 

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/ShellViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/ShellViewModel.cs
@@ -7,10 +7,12 @@
 
 using System;
 using System.Linq;
+using System.Windows.Input;
 using Caliburn.Micro;
 using ChocolateyGui.Common.Models.Messages;
 using ChocolateyGui.Common.Providers;
 using ChocolateyGui.Common.Services;
+using ChocolateyGui.Common.Windows.Commands;
 using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.ViewModels.Items;
 
@@ -46,7 +48,10 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             _configService = configService;
             Sources = new BindableCollection<SourceViewModel>();
             ActiveItem = _sourcesViewModel;
+            GoToSourceCommand = new RelayCommand(GoToSource, CanGoToSource);
         }
+
+        public ICommand GoToSourceCommand { get; }
 
         public string AboutInformation
             => ResourceReader.GetFromResources(GetType().Assembly, "ChocolateyGui.Resources.ABOUT.md");
@@ -144,6 +149,28 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         protected override void OnInitialize()
         {
             _eventAggregator.Subscribe(this);
+        }
+
+        private bool CanGoToSource(object obj)
+        {
+            return obj is int sourceIndex
+                && sourceIndex > 0
+                && sourceIndex <= _sourcesViewModel.Items.Count;
+        }
+
+        private void GoToSource(object obj)
+        {
+            if (obj is int sourceIndex)
+            {
+                --sourceIndex;
+
+                if (sourceIndex < 0 || sourceIndex > _sourcesViewModel.Items.Count)
+                {
+                    return;
+                }
+
+                _sourcesViewModel.ActivateItem(_sourcesViewModel.Items[sourceIndex]);
+            }
         }
 
         private void SetActiveItem<T>(T newItem)

--- a/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml
@@ -6,6 +6,7 @@
                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                    xmlns:cal="http://www.caliburnproject.org"
                    xmlns:properties="clr-namespace:ChocolateyGui.Common.Properties;assembly=ChocolateyGui.Common"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib"
                    xmlns:viewModels="clr-namespace:ChocolateyGui.Common.Windows.ViewModels;assembly=ChocolateyGui.Common.Windows"
                    mc:Ignorable="d"
                    Height="768" Width="1366"
@@ -22,6 +23,54 @@
             Executed="PerformGoToPage"
             CanExecute="CanGoToPage" />
     </Window.CommandBindings>
+    <Window.InputBindings>
+        <KeyBinding Gesture="Ctrl+1" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>1</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+2" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>2</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+3" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>3</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+4" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>4</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+5" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>5</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+6" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>6</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+7" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>7</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+8" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>8</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+9" Command="{Binding GoToSourceCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>9</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+
+    </Window.InputBindings>
     <Window.Title>
         <PriorityBinding>
             <Binding Path="ActiveItem.DisplayName"></Binding>


### PR DESCRIPTION
Fix 513 by adding keyboard bindings ctrl+1..9 to switch between respective source indexes.

Closes #513