### PR TITLE
(GH-706) Add a settings to prevent searchs preloading

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -221,6 +221,12 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                     return;
                 }
 
+                if (!_hasLoaded && _configService.GetAppConfiguration().PreventPreload)
+                {
+                    _hasLoaded = true;
+                    return;
+                }
+
                 _hasLoaded = false;
 
                 var sort = SortSelection == Resources.RemoteSourceViewModel_SortSelectionPopularity ? "DownloadCount" : "Title";

--- a/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
+++ b/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
@@ -33,6 +33,10 @@ namespace ChocolateyGui.Common.Models
         [Feature]
         public bool UseDelayedSearch { get; set; }
 
+        [LocalizedDescription("SettingsView_TogglePreventPreloadDescription")]
+        [Feature]
+        public bool PreventPreload { get; set; }
+
         [LocalizedDescription("SettingsView_ToggleExcludeInstalledPackagesDescription")]
         [Feature]
         public bool ExcludeInstalledPackages { get; set; }

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -2076,6 +2076,15 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prevents preloading results with a blank search when opening the remote source view..
+        /// </summary>
+        public static string SettingsView_TogglePreventPreloadDescription {
+            get {
+                return ResourceManager.GetString("SettingsView_TogglePreventPreloadDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show additional package information on Local and Remote views..
         /// </summary>
         public static string SettingsView_ToggleShowAdditionalPackageInformationDescription {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -677,6 +677,9 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   <data name="SettingsView_ToggleShowAggregatedSourceViewDescription" xml:space="preserve">
     <value>Show additional source combining all sources in one place.</value>
   </data>
+  <data name="SettingsView_TogglePreventPreloadDescription" xml:space="preserve">
+    <value>Prevents preloading results with a blank search when opening the remote source view.</value>
+  </data>
   <data name="SourcesView_AggregatedSourcesId" xml:space="preserve">
     <value>All Sources</value>
   </data>


### PR DESCRIPTION
Add a toggle in the settings view to prevent a blank search when viewing
the list of available packages.

https://github.com/chocolatey/ChocolateyGUI/issues/706