### PR TITLE
Show message at remote source view when no packages were found by search input

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Utilities\Converters\EnumToBoolConverter.cs" />
     <Compile Include="Utilities\Converters\LongSizeToFileSizeString.cs" />
     <Compile Include="Utilities\Converters\MultiBooleanAndToVisibility.cs" />
+    <Compile Include="Utilities\Converters\NullToBool.cs" />
     <Compile Include="Utilities\Converters\NullToValue.cs" />
     <Compile Include="Utilities\Converters\NullToVisibility.cs" />
     <Compile Include="Utilities\Converters\PackageDependenciesToString.cs" />

--- a/Source/ChocolateyGui.Common.Windows/Controls/Dialogs/ChocolateyDialog.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Controls/Dialogs/ChocolateyDialog.xaml
@@ -11,7 +11,7 @@
                          x:Class="ChocolateyGui.Common.Windows.Controls.Dialogs.ChocolateyDialog"
                          x:Name="PART_Dialog"
                          Background="{StaticResource BackgroundColorBrush}" d:DesignWidth="1300">
-    <MahDialogs:BaseMetroDialog.Content>
+    <MahDialogs:CustomDialog.Content>
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
@@ -32,14 +32,14 @@
                 <Button x:Name="PART_NegativeButton"
                         Height="35"
                         MinWidth="80"
-                        Style="{DynamicResource AccentedDialogSquareButton}"
+                        Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}"
                         Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=dialogs:ChocolateyDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                         Margin="5 0 0 0"
                         Visibility="Hidden" />
             </StackPanel>
         </Grid>
-    </MahDialogs:BaseMetroDialog.Content>
-    <MahDialogs:BaseMetroDialog.DialogBottom>
+    </MahDialogs:CustomDialog.Content>
+    <MahDialogs:CustomDialog.DialogBottom>
         <MahControls:MetroProgressBar
             HorizontalAlignment="Stretch"
             VerticalAlignment="Bottom"
@@ -53,5 +53,5 @@
             Maximum="1.0"
             Foreground="{Binding ProgressBarForeground, RelativeSource={RelativeSource AncestorType=dialogs:ChocolateyDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
             x:Name="PART_ProgressBar" />
-    </MahDialogs:BaseMetroDialog.DialogBottom>
+    </MahDialogs:CustomDialog.DialogBottom>
 </MahDialogs:CustomDialog>

--- a/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NullToBool.cs
+++ b/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NullToBool.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="NullToBool.cs">
+//   Copyright 2017 - Present Chocolatey Software, LLC
+//   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ChocolateyGui.Common.Windows.Utilities.Converters
+{
+    public class NullToBool : NullToValue
+    {
+        public NullToBool()
+        {
+            TrueValue = true;
+            FalseValue = false;
+        }
+    }
+}

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -81,6 +81,12 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             _eventAggregator.Subscribe(this);
         }
 
+        public bool HasLoaded
+        {
+            get { return _hasLoaded; }
+            set { this.SetPropertyValue(ref _hasLoaded, value); }
+        }
+
         public bool ShowShouldPreventPreloadMessage
         {
             get { return _shouldShowPreventPreloadMessage; }
@@ -209,7 +215,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         public bool CanLoadRemotePackages()
         {
-            return _hasLoaded;
+            return HasLoaded;
         }
 
         public void RefreshRemotePackages()
@@ -228,14 +234,14 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                     return;
                 }
 
-                if (!_hasLoaded && _configService.GetAppConfiguration().PreventPreload)
+                if (!HasLoaded && _configService.GetAppConfiguration().PreventPreload)
                 {
                     ShowShouldPreventPreloadMessage = true;
-                    _hasLoaded = true;
+                    HasLoaded = true;
                     return;
                 }
 
-                _hasLoaded = false;
+                HasLoaded = false;
                 ShowShouldPreventPreloadMessage = false;
 
                 var sort = SortSelection == Resources.RemoteSourceViewModel_SortSelectionPopularity ? "DownloadCount" : "Title";
@@ -291,7 +297,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                 finally
                 {
                     await _progressService.StopLoading();
-                    _hasLoaded = true;
+                    HasLoaded = true;
                 }
 
                 await _eventAggregator.PublishOnUIThreadAsync(new ResetScrollPositionMessage());

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -229,9 +229,13 @@
                                         </Grid>
                                     </Border>
                                     <ControlTemplate.Triggers>
-                                        <DataTrigger Binding="{Binding SearchQuery, Mode=OneWay, Converter={StaticResource NullToBool}}" Value="False">
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding HasLoaded, Mode=OneWay}" Value="True" />
+                                                <Condition Binding="{Binding ShowShouldPreventPreloadMessage, Mode=OneWay}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
                                             <Setter TargetName="EmptySearchInfo" Property="Visibility" Value="Visible" />
-                                        </DataTrigger>
+                                        </MultiDataTrigger>
                                         <DataTrigger Binding="{Binding MatchWord, Mode=OneWay}" Value="True">
                                             <Setter TargetName="EmptySearchInfo" Property="Visibility" Value="Visible" />
                                         </DataTrigger>

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -215,12 +215,12 @@
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                             <StackPanel x:Name="EmptySearchInfo" Visibility="Collapsed" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
                                                 <iconPacks:PackIconOcticons Kind="Search" Width="72" Height="72" Foreground="{DynamicResource MahApps.Brushes.AccentBase}" HorizontalAlignment="Center" Margin="20" />
-                                                <TextBlock Text="No matching packages found..."
+                                                <TextBlock Text="{x:Static properties:Resources.RemoteSourceView_SearchNoPackagesFound}"
                                                            HorizontalAlignment="Center"
                                                            FontSize="28"
                                                            Margin="10"
                                                            TextWrapping="Wrap"/>
-                                                <TextBlock Text="Change your search keywords and options and try it again."
+                                                <TextBlock Text="{x:Static properties:Resources.RemoteSourceView_SearchNoPackagesFoundHeading}"
                                                            HorizontalAlignment="Center"
                                                            FontSize="20"
                                                            Margin="5"

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -23,6 +23,7 @@
             <converters:PackageTitleConverter x:Key="PackageTitleConverter"/>
             <converters:MultiBooleanAndToVisibility x:Key="MultiBooleanAndToVisibility" />
             <converters:EnumToBoolConverter x:Key="EnumToBoolConverter" />
+            <converters:NullToBool x:Key="NullToBool" />
 
             <utilities:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
 
@@ -200,6 +201,48 @@
                 <Setter Property="ItemTemplate" Value="{StaticResource PackageListTemplate}" />
                 <Setter Property="VerticalContentAlignment" Value="Stretch" />
                 <Style.Triggers>
+                    <Trigger Property="HasItems" Value="False">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListView}">
+                                    <Border x:Name="Border"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                        <Grid Margin="{TemplateBinding Padding}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                            <StackPanel x:Name="EmptySearchInfo" Visibility="Collapsed" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <iconPacks:PackIconOcticons Kind="Search" Width="72" Height="72" Foreground="{DynamicResource MahApps.Brushes.AccentBase}" HorizontalAlignment="Center" Margin="20" />
+                                                <TextBlock Text="No matching packages found..."
+                                                           HorizontalAlignment="Center"
+                                                           FontSize="28"
+                                                           Margin="10"
+                                                           TextWrapping="Wrap"/>
+                                                <TextBlock Text="Change your search keywords and options and try it again."
+                                                           HorizontalAlignment="Center"
+                                                           FontSize="20"
+                                                           Margin="5"
+                                                           TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Grid>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <DataTrigger Binding="{Binding SearchQuery, Mode=OneWay, Converter={StaticResource NullToBool}}" Value="False">
+                                            <Setter TargetName="EmptySearchInfo" Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding MatchWord, Mode=OneWay}" Value="True">
+                                            <Setter TargetName="EmptySearchInfo" Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Gray9}" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
                     <DataTrigger Binding="{Binding ListViewMode, Mode=OneWay}" Value="{x:Static enums:ListViewMode.Tile}">
                         <Setter Property="ItemTemplate" Value="{StaticResource PackageTileTemplate}" />
                         <Setter Property="ItemContainerStyle" Value="{StaticResource ListViewItemTileStyle}" />
@@ -310,7 +353,7 @@
                     Style="{DynamicResource PaginationButtonStyle}"/>
         </Grid>
 
-<Grid Grid.Row="1">
+        <Grid Grid.Row="1">
             <ListView x:Name="Packages" ItemsSource="{Binding Packages, Mode=OneWay}"
                       VerticalAlignment="Stretch"
                       HorizontalContentAlignment="Stretch"

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -1634,6 +1634,24 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No matching packages found....
+        /// </summary>
+        public static string RemoteSourceView_SearchNoPackagesFound {
+            get {
+                return ResourceManager.GetString("RemoteSourceView_SearchNoPackagesFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change the search string, and/or options used, and try again..
+        /// </summary>
+        public static string RemoteSourceView_SearchNoPackagesFoundHeading {
+            get {
+                return ResourceManager.GetString("RemoteSourceView_SearchNoPackagesFoundHeading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to Load.
         /// </summary>
         public static string RemoteSourceViewModel_FailedToLoad {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -955,4 +955,10 @@ Normal:
   <data name="RemoteSourceView_PreventPreloadSubHeading" xml:space="preserve">
     <value>Please search for a package using the search box above.</value>
   </data>
+  <data name="RemoteSourceView_SearchNoPackagesFound" xml:space="preserve">
+    <value>No matching packages found...</value>
+  </data>
+  <data name="RemoteSourceView_SearchNoPackagesFoundHeading" xml:space="preserve">
+    <value>Change the search string, and/or options used, and try again.</value>
+  </data>
 </root>


### PR DESCRIPTION
Add a ListView template to show a message when no matching packages were found.

![2020-04-04_12h03_56](https://user-images.githubusercontent.com/658431/78424391-7aaea480-766d-11ea-9811-52a241bbad5e.png)

![2020-04-04_12h04_34](https://user-images.githubusercontent.com/658431/78424394-7d10fe80-766d-11ea-8cb0-757716a20624.png)

Closes #742 