### PR TITLE
(GH-745) Reorder local and remote context menu and bring back menu icons

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
@@ -27,34 +27,175 @@
     <converters:StringListToString x:Key="StringListToString" />
     <converters:BooleanInverter x:Key="BooleanInverter" />
 
-    <Style x:Key="UacIconStyle" TargetType="{x:Type Image}">
-        <Setter Property="Source" Value="{x:Static windows:NativeMethods.UacIcon}"/>
-        <Setter Property="Visibility" Value="{Binding Path=IsElevated, Source={x:Static windows:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
-    </Style>
+    <!-- todo remove this after next MahApps update -->
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Grid SnapsToDevicePixels="True">
+            <Rectangle x:Name="Bg"
+                       Fill="{TemplateBinding Background}"
+                       Stroke="{TemplateBinding BorderBrush}"
+                       StrokeThickness="1" />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"
+                                      MinWidth="24"
+                                      SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="6" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="17" />
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  ContentSource="Icon"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Path x:Name="GlyphPanel"
+                      Margin="5 0 0 0"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Data="{DynamicResource Checkmark}"
+                      Fill="{DynamicResource MahApps.Brushes.CheckmarkFill}"
+                      FlowDirection="LeftToRight"
+                      Visibility="Collapsed" />
+                <ContentPresenter Grid.Column="2"
+                                  Margin="{TemplateBinding Padding}"
+                                  ContentSource="Header"
+                                  RecognizesAccessKey="True"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <TextBlock Grid.Column="4"
+                           Margin="{TemplateBinding Padding}"
+                           Text="{TemplateBinding InputGestureText}"
+                           Visibility="Collapsed" />
+                <Path Grid.Column="5"
+                      Margin="4 0 0 0"
+                      VerticalAlignment="Center"
+                      Data="{DynamicResource RightArrow}"
+                      Fill="{DynamicResource MahApps.Brushes.RightArrowFill}" />
+            </Grid>
+            <Popup x:Name="PART_Popup"
+                   AllowsTransparency="True"
+                   Focusable="False"
+                   HorizontalOffset="-2"
+                   IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                   Placement="Right"
+                   PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
+                   VerticalOffset="-3">
+                <Grid>
+                    <Rectangle x:Name="LayoutRoot" Fill="{TemplateBinding Background}" />
+                    <ContentControl x:Name="SubMenuBorder"
+                                    IsTabStop="False"
+                                    Template="{DynamicResource {ComponentResourceKey ResourceId=SubmenuContent, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                        <ScrollViewer x:Name="SubMenuScrollViewer"
+                                      CanContentScroll="True"
+                                      Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                            <ItemsPresenter x:Name="ItemsPresenter"
+                                            Margin="0"
+                                            Grid.IsSharedSizeScope="True"
+                                            KeyboardNavigation.DirectionalNavigation="Cycle"
+                                            KeyboardNavigation.TabNavigation="Cycle"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </ScrollViewer>
+                    </ContentControl>
+                </Grid>
+            </Popup>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsSuspendingPopupAnimation" Value="True">
+                <Setter TargetName="PART_Popup" Property="PopupAnimation" Value="None" />
+            </Trigger>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger SourceName="PART_Popup" Property="HasDropShadow" Value="True">
+                <Setter TargetName="LayoutRoot" Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect BlurRadius="4"
+                                          Direction="315"
+                                          Opacity="0.3"
+                                          ShadowDepth="2"
+                                          Color="{DynamicResource MahApps.Colors.MenuShadow}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter TargetName="LayoutRoot" Property="Margin" Value="0 0 6 6" />
+                <Setter TargetName="SubMenuBorder" Property="Margin" Value="0 0 6 6" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="Bg" Property="Fill" Value="{DynamicResource MahApps.Brushes.MenuItem.SelectionFill}" />
+                <Setter TargetName="Bg" Property="Stroke" Value="{DynamicResource MahApps.Brushes.MenuItem.SelectionStroke}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.MenuItem.Foreground.Disabled}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{DynamicResource MahApps.Brushes.MenuItem.GlyphPanel.Disabled}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
 
-    <Image x:Key="UacIcon" x:Shared="False"
-          Style="{StaticResource UacIconStyle}"
-          Width="16" Height="16"/>
-
-    <Style x:Key="PrimaryUacIconStyle" TargetType="{x:Type Image}">
-        <Setter Property="Source" Value="{x:Static windows:NativeMethods.UacIcon}"/>
-        <Setter Property="Visibility" Value="{Binding Path=CanDoCentralActions, Source={x:Static windows:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
-    </Style>
-
-    <Image x:Key="PrimaryUacIcon" x:Shared="False"
-          Style="{StaticResource PrimaryUacIconStyle}"
-          Width="16" Height="16"/>
-
-    <Style x:Key="TertiaryUacIconStyle" TargetType="{x:Type Image}">
-        <Setter Property="Source" Value="{x:Static windows:NativeMethods.UacIcon}"/>
-        <Setter Property="Visibility" Value="{Binding Path=CanDoTertiaryActions, Source={x:Static windows:Elevation.Instance}, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"/>
-    </Style>
-
-    <Image x:Key="TertiaryUacIcon" x:Shared="False"
-          Style="{StaticResource TertiaryUacIconStyle}"
-          Width="16" Height="16"/>
-
-    <system:Double x:Key="ToggleSwitchFontSize">15</system:Double>
+    <!-- todo remove this after next MahApps update -->
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Grid SnapsToDevicePixels="True">
+            <Rectangle x:Name="Bg"
+                       Fill="{TemplateBinding Background}"
+                       Stroke="{TemplateBinding BorderBrush}"
+                       StrokeThickness="1" />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"
+                                      MinWidth="24"
+                                      SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="6" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="17" />
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  ContentSource="Icon"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Path x:Name="GlyphPanel"
+                      Margin="5 0 0 0"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Data="{DynamicResource Checkmark}"
+                      Fill="{DynamicResource MahApps.Brushes.CheckmarkFill}"
+                      FlowDirection="LeftToRight"
+                      Visibility="Collapsed" />
+                <ContentPresenter Grid.Column="2"
+                                  Margin="{TemplateBinding Padding}"
+                                  ContentSource="Header"
+                                  RecognizesAccessKey="True"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <TextBlock Grid.Column="4"
+                           Margin="{TemplateBinding Padding}"
+                           Text="{TemplateBinding InputGestureText}" />
+            </Grid>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="Bg" Property="Fill" Value="{DynamicResource MahApps.Brushes.MenuItem.SelectionFill}" />
+                <Setter TargetName="Bg" Property="Stroke" Value="{DynamicResource MahApps.Brushes.MenuItem.SelectionStroke}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.MenuItem.Foreground.Disabled}" />
+                <Setter TargetName="GlyphPanel" Property="Fill" Value="{DynamicResource MahApps.Brushes.MenuItem.GlyphPanel.Disabled}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
 
     <Style x:Key="SourceBaseTextBlockStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="FontFamily" Value="./Resources/#SourceSansPro-Regular" />
@@ -497,7 +638,7 @@
                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
                  d:DataContext="{d:DesignInstance Type=items:PackageViewModel}">
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuPin}"
-                  Icon="{StaticResource TertiaryUacIcon}"
+                  Icon="{iconPacks:Modern Kind=Pin}"
                   Command="{commands:DataContextCommandAdapter Pin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -507,7 +648,7 @@
             </MenuItem.Visibility>
         </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUnpin}"
-                  Icon="{StaticResource TertiaryUacIcon}"
+                  Icon="{iconPacks:Modern Kind=PinRemove}"
                   Command="{commands:DataContextCommandAdapter Unpin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -517,22 +658,23 @@
             </MenuItem.Visibility>
         </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuDetails}"
+                  Icon="{iconPacks:BoxIcons Kind=RegularInfoCircle}"
                   Command="{commands:DataContextCommandAdapter ViewDetails}" />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUpdate}"
-                  Icon="{StaticResource PrimaryUacIcon}"
+                  Icon="{iconPacks:Entypo Kind=Cycle}"
                   Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Update}" />
         <Separator />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuInstall}"
-                  Icon="{StaticResource PrimaryUacIcon}"
+                  Icon="{iconPacks:Entypo Kind=Install}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"
                   Command="{commands:DataContextCommandAdapter Install}" />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuReinstall}"
-                  Icon="{StaticResource PrimaryUacIcon}"
+                  Icon="{iconPacks:Entypo Kind=Cw}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Reinstall}" />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUninstall}"
-                  Icon="{StaticResource PrimaryUacIcon}"
+                  Icon="{iconPacks:Entypo Kind=Uninstall}"
                   Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Uninstall}" />
     </ContextMenu>

--- a/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
@@ -496,10 +496,8 @@
     <ContextMenu x:Key="PackagesContextMenu"
                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
                  d:DataContext="{d:DesignInstance Type=items:PackageViewModel}">
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuInstall}" Icon="{StaticResource PrimaryUacIcon}"
-                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"
-                  Command="{commands:DataContextCommandAdapter Install}" />
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuPin}" Icon="{StaticResource TertiaryUacIcon}"
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuPin}"
+                  Icon="{StaticResource TertiaryUacIcon}"
                   Command="{commands:DataContextCommandAdapter Pin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -508,7 +506,8 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUnpin}" Icon="{StaticResource TertiaryUacIcon}"
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUnpin}"
+                  Icon="{StaticResource TertiaryUacIcon}"
                   Command="{commands:DataContextCommandAdapter Unpin}">
             <MenuItem.Visibility>
                 <MultiBinding Converter="{StaticResource BooleanToVisibility}">
@@ -517,16 +516,25 @@
                 </MultiBinding>
             </MenuItem.Visibility>
         </MenuItem>
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUninstall}" Icon="{StaticResource PrimaryUacIcon}"
-                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Uninstall}" />
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuReinstall}" Icon="{StaticResource PrimaryUacIcon}"
-                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Reinstall}" />
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUpdate}" Icon="{StaticResource PrimaryUacIcon}"
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuDetails}"
+                  Command="{commands:DataContextCommandAdapter ViewDetails}" />
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUpdate}"
+                  Icon="{StaticResource PrimaryUacIcon}"
                   Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}"
                   Command="{commands:DataContextCommandAdapter Update}" />
-        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuDetails}" Command="{commands:DataContextCommandAdapter ViewDetails}" />
+        <Separator />
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuInstall}"
+                  Icon="{StaticResource PrimaryUacIcon}"
+                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}"
+                  Command="{commands:DataContextCommandAdapter Install}" />
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuReinstall}"
+                  Icon="{StaticResource PrimaryUacIcon}"
+                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
+                  Command="{commands:DataContextCommandAdapter Reinstall}" />
+        <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUninstall}"
+                  Icon="{StaticResource PrimaryUacIcon}"
+                  Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}"
+                  Command="{commands:DataContextCommandAdapter Uninstall}" />
     </ContextMenu>
 
     <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource {x:Type DataGrid}}">

--- a/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
@@ -29,19 +29,6 @@
         <converters:PackageDependenciesToString x:Key="PackageDependenciesToString" />
         <converters:MultiBooleanAndToVisibility x:Key="MultiBooleanAndToVisibility" />
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
-
-        <Style x:Key="PrimaryUacActionStyle" BasedOn="{StaticResource PrimaryUacIconStyle}" TargetType="Image">
-            <Setter Property="Width" Value="16"/>
-            <Setter Property="Height" Value="16"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="0 0 5 0"/>
-        </Style>
-        <Style x:Key="TertiaryUacActionStyle" BasedOn="{StaticResource TertiaryUacIconStyle}" TargetType="Image">
-            <Setter Property="Width" Value="16"/>
-            <Setter Property="Height" Value="16"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="0 0 5 0"/>
-        </Style>
     </UserControl.Resources>
 
     <DockPanel x:Name="PackageViewGrid" LastChildFill="True" DataContext="{Binding Package}"
@@ -82,7 +69,6 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Install}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Install" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonInstall}" FontSize="16"/>
                             </StackPanel>
@@ -94,7 +80,6 @@
                                 Command="{commands:DataContextCommandAdapter Pin}"
                                 Visibility="{Binding IsPinned, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="Pin" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonPin}" FontSize="16"/>
                             </StackPanel>
@@ -103,7 +88,6 @@
                                 Command="{commands:DataContextCommandAdapter Unpin}"
                                 Visibility="{Binding IsPinned, Converter={StaticResource BooleanToVisibility}}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource TertiaryUacActionStyle}" />
                                 <iconPacks:PackIconModern Kind="PinRemove" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUnpin}" FontSize="16"/>
                             </StackPanel>
@@ -111,7 +95,6 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Reinstall}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cw" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonReinstall}" FontSize="16"/>
                             </StackPanel>
@@ -119,7 +102,6 @@
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Uninstall}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Uninstall" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUninstall}" FontSize="16"/>
                             </StackPanel>
@@ -128,7 +110,6 @@
                             Command="{commands:DataContextCommandAdapter Update}"
                             Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Style="{StaticResource PrimaryUacActionStyle}" />
                                 <iconPacks:PackIconEntypo Kind="Cycle" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUpdate}" FontSize="16"/>
                             </StackPanel>


### PR DESCRIPTION
Reorder local and remote context menu and bring back menu icons.

- [x] Reorder Context Menu for local and remote source
- [x] Add icons back to PackagesContextMenu and remove old unused Uac icon image styles

![2020-04-07_23h58_18](https://user-images.githubusercontent.com/658431/78724445-c7c09e00-792d-11ea-8c5b-36871c6707fe.png)

![2020-04-07_23h58_31](https://user-images.githubusercontent.com/658431/78724446-c8593480-792d-11ea-9233-1a2109309130.png)

![2020-04-07_23h58_42](https://user-images.githubusercontent.com/658431/78724447-c8593480-792d-11ea-8d7a-533341902c79.png)

![2020-04-07_23h58_50](https://user-images.githubusercontent.com/658431/78724448-c8f1cb00-792d-11ea-90b2-00f3dddd0876.png)

Closes #745 
