### PR TITLE
(GH-754) Add missing helper.ps1 file to nuspec file

### DIFF
--- a/nuspec/chocolatey/ChocolateyGUI.nuspec
+++ b/nuspec/chocolatey/ChocolateyGUI.nuspec
@@ -56,6 +56,7 @@ All release notes for Chocolatey GUI can be found on the GitHub site - https://g
   <files>
     <file src="chocolateyInstall.ps1" target="tools"/>
     <file src="chocolateyUninstall.ps1" target="tools"/>
+    <file src="helper.ps1" target="tools"/>
     <file src="..\..\BuildArtifacts\ChocolateyGUI.msi" target="tools"/>
     <file src="..\..\LICENSE.txt" target="tools\LICENSE.txt"/>
     <file src="VERIFICATION.txt" target="tools"/>


### PR DESCRIPTION
In #741 I added a helper.ps1 file. This file was never added to the Chocolatey package.
Merging this fixes that.

Fixes #754 