### PR TITLE
(GH-756) Improve Svg icon rendering by using Svg.Skia (SkiaSharp)

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -78,9 +78,6 @@
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Magick.NET-Q16-AnyCPU, Version=7.5.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
-      <HintPath>..\packages\Magick.NET-Q16-AnyCPU.7.5.0\lib\net40\Magick.NET-Q16-AnyCPU.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro, Version=2.0.0.0, Culture=neutral, PublicKeyToken=51482d6f650b2b3f, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.2.0.0-alpha0531\lib\net45\MahApps.Metro.dll</HintPath>

--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -66,6 +66,12 @@
     </Reference>
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.4.1.1\lib\net45\ControlzEx.dll</HintPath>
+    </Reference>
+    <Reference Include="Fizzler, Version=1.2.0.0, Culture=neutral, PublicKeyToken=4ebff4844e382110, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fizzler.1.2.0\lib\netstandard1.0\Fizzler.dll</HintPath>
+    </Reference>
+    <Reference Include="HarfBuzzSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\HarfBuzzSharp.2.6.1.1\lib\net45\HarfBuzzSharp.dll</HintPath>
     </Reference>
     <Reference Include="LiteDB, Version=3.1.4.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.3.1.4\lib\net35\LiteDB.dll</HintPath>
@@ -171,14 +177,32 @@
     <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
     </Reference>
+    <Reference Include="SkiaSharp, Version=1.68.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\SkiaSharp.1.68.1.1\lib\net45\SkiaSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SkiaSharp.HarfBuzz, Version=1.68.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\SkiaSharp.HarfBuzz.1.68.1.1\lib\net45\SkiaSharp.HarfBuzz.dll</HintPath>
+    </Reference>
     <Reference Include="Splat, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Splat.2.0.0\lib\Net45\Splat.dll</HintPath>
     </Reference>
+    <Reference Include="Svg.Custom, Version=0.0.0.0, Culture=neutral, PublicKeyToken=dafe96fe6c845a74, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.Custom.0.1.7\lib\net452\Svg.Custom.dll</HintPath>
+    </Reference>
+    <Reference Include="Svg.Skia, Version=0.1.7.0, Culture=neutral, PublicKeyToken=dafe96fe6c845a74, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.Skia.0.1.7\lib\net452\Svg.Skia.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
@@ -197,6 +221,12 @@
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -401,4 +431,13 @@
     </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets" Condition="Exists('..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets'))" />
+  </Target>
+  <Import Project="..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets')" />
 </Project>

--- a/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
@@ -90,7 +90,7 @@ namespace ChocolateyGui.Common.Windows.Controls
         private static bool IsSvg(string url)
         {
             var extension = Path.GetExtension(url)?.ToLower();
-            return extension is ".svg" || extension is ".svgz";
+            return extension == ".svg" || extension == ".svgz";
         }
 
         private static void ExtractImageFromStream(string url, Size desiredSize, Stream inputStream, Stream imageStream)

--- a/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows;
@@ -16,7 +15,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Caliburn.Micro;
 using ChocolateyGui.Common.Windows.Utilities.Extensions;
-using ImageMagick;
 using LiteDB;
 using MahApps.Metro.IconPacks;
 using Microsoft.VisualStudio.Threading;
@@ -89,23 +87,15 @@ namespace ChocolateyGui.Common.Windows.Controls
             imageStream.Position = 0;
         }
 
-        private static IMagickImage ExtractImage(MagickImageCollection imageCollection, Size desiredSize)
+        private static bool IsSvg(string url)
         {
-            var imagesOrderedBySize = imageCollection
-                .OrderBy(f => f.Width)
-                .ThenBy(f => f.Height)
-                .ToList();
-
-            // if there is no matching image, get the largest image
-            return imagesOrderedBySize
-                       .FirstOrDefault(f => f.Width >= desiredSize.Width
-                                            && f.Height >= desiredSize.Height)
-                   ?? imagesOrderedBySize.Last();
+            var extension = Path.GetExtension(url)?.ToLower();
+            return extension is ".svg" || extension is ".svgz";
         }
 
-        private static async Task ExtractImageFromStream(string url, Size desiredSize, MagickReadSettings readSettings, Stream inputStream, MemoryStream imageStream)
+        private static void ExtractImageFromStream(string url, Size desiredSize, Stream inputStream, Stream imageStream)
         {
-            if (readSettings.Format == MagickFormat.Svg || readSettings.Format == MagickFormat.Svgz)
+            if (IsSvg(url))
             {
                 using (var svg = new SKSvg())
                 {
@@ -147,17 +137,51 @@ namespace ChocolateyGui.Common.Windows.Controls
             }
             else
             {
-                using (var images = new MagickImageCollection(inputStream, readSettings))
+                var bitmap = SKBitmap.Decode(inputStream);
+                if (bitmap != null)
                 {
-                    var image = ExtractImage(images, desiredSize);
+                    var resizeInfo = GetResizeSkImageInfo(desiredSize, bitmap);
+                    using (var resizedBitmap = bitmap.Resize(resizeInfo, SKFilterQuality.High))
+                    {
+                        bitmap.Dispose();
 
-                    image.Resize((int)desiredSize.Width, 0);
-
-                    image.Write(imageStream, MagickFormat.Png);
-
-                    await imageStream.FlushAsync();
+                        using (var image = SKImage.FromBitmap(resizedBitmap))
+                        {
+                            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+                            {
+                                data.SaveTo(imageStream);
+                            }
+                        }
+                    }
                 }
             }
+        }
+
+        private static SKImageInfo GetResizeSkImageInfo(Size desiredSize, SKBitmap bitmap)
+        {
+            var resizeInfo = new SKImageInfo((int)desiredSize.Width, (int)desiredSize.Height);
+
+            // Test whether there is more room in width or height
+            if (Math.Abs(bitmap.Width - desiredSize.Width) > Math.Abs(bitmap.Height - desiredSize.Height))
+            {
+                // More room in width, so leave image width set to canvas width
+                // and increase/decrease height by same ratio
+                var widthRatio = (double)desiredSize.Width / (double)bitmap.Width;
+                var newHeight = (int)Math.Floor(bitmap.Height * widthRatio);
+
+                resizeInfo.Height = newHeight;
+            }
+            else
+            {
+                // More room in height, so leave image height set to canvas height
+                // and increase/decrease width by same ratio
+                var heightRatio = (double)desiredSize.Height / (double)bitmap.Height;
+                var newWidth = (int)Math.Floor(bitmap.Width * heightRatio);
+
+                resizeInfo.Width = newWidth;
+            }
+
+            return resizeInfo;
         }
 
         private async Task<IBitmap> LoadImage(string url, Size desiredSize, DateTime absoluteExpiration)
@@ -188,8 +212,6 @@ namespace ChocolateyGui.Common.Windows.Controls
                 }
             }
 
-            var readSettings = GetMagickReadSettings(url);
-
             // If we couldn't find the image or it expired
             using (var client = new HttpClient())
             {
@@ -201,7 +223,7 @@ namespace ChocolateyGui.Common.Windows.Controls
                     await response.Content.CopyToAsync(memoryStream);
                     memoryStream.Position = 0;
 
-                    await ExtractImageFromStream(url, desiredSize, readSettings, memoryStream, imageStream).ConfigureAwait(false);
+                    ExtractImageFromStream(url, desiredSize, memoryStream, imageStream);
                 }
             }
 
@@ -252,46 +274,12 @@ namespace ChocolateyGui.Common.Windows.Controls
             PART_Loading.IsActive = false;
         }
 
-        private MagickReadSettings GetMagickReadSettings(string url)
-        {
-            var extension = GetExtension(url);
-
-            MagickFormat format;
-            if (Enum.TryParse<MagickFormat>(extension, true, out format) == false)
-            {
-                ////throw new Exception($"Image format with extension '{extension}' from '{url}' is currently not supported.");
-
-                return new MagickReadSettings();
-            }
-
-            var readSettings = new MagickReadSettings { Format = format };
-            return readSettings;
-        }
-
         private Size GetCurrentSize()
         {
             var scale = NativeMethods.GetScaleFactor();
             var x = (int)Math.Round(ActualWidth * scale);
             var y = (int)Math.Round(ActualHeight * scale);
             return new Size(x, y);
-        }
-
-        private string GetExtension(string url)
-        {
-            Uri uri;
-            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
-            {
-                throw new ArgumentException(nameof(url));
-            }
-
-            var imagePart = uri.Segments.Last();
-            var fileTypeSeperator = imagePart.LastIndexOf(".", StringComparison.InvariantCulture);
-            if (fileTypeSeperator <= 0)
-            {
-                return string.Empty;
-            }
-
-            return imagePart.Substring(fileTypeSeperator + 1);
         }
     }
 }

--- a/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Controls/InternetImage.xaml.cs
@@ -201,7 +201,7 @@ namespace ChocolateyGui.Common.Windows.Controls
                     await response.Content.CopyToAsync(memoryStream);
                     memoryStream.Position = 0;
 
-                    await ExtractImageFromStream(url, desiredSize, readSettings, memoryStream, imageStream);
+                    await ExtractImageFromStream(url, desiredSize, readSettings, memoryStream, imageStream).ConfigureAwait(false);
                 }
             }
 

--- a/Source/ChocolateyGui.Common.Windows/app.config
+++ b/Source/ChocolateyGui.Common.Windows/app.config
@@ -1,5 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
 </configuration>

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -11,7 +11,6 @@
   <package id="HarfBuzzSharp" version="2.6.1.1" targetFramework="net452" />
   <package id="LiteDB" version="3.1.4" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
-  <package id="Magick.NET-Q16-AnyCPU" version="7.5.0" targetFramework="net452" />
   <package id="MahApps.Metro" version="2.0.0-alpha0531" targetFramework="net452" />
   <package id="MahApps.Metro.IconPacks" version="3.0.0-alpha0255" targetFramework="net452" />
   <package id="Markdig.Signed" version="0.17.1" targetFramework="net452" />

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -7,6 +7,8 @@
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net40" requireReinstallation="true" />
   <package id="chocolatey.lib" version="0.10.15" targetFramework="net452" />
   <package id="ControlzEx" version="4.1.1" targetFramework="net452" />
+  <package id="Fizzler" version="1.2.0" targetFramework="net452" />
+  <package id="HarfBuzzSharp" version="2.6.1.1" targetFramework="net452" />
   <package id="LiteDB" version="3.1.4" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Magick.NET-Q16-AnyCPU" version="7.5.0" targetFramework="net452" />
@@ -14,20 +16,31 @@
   <package id="MahApps.Metro.IconPacks" version="3.0.0-alpha0255" targetFramework="net452" />
   <package id="Markdig.Signed" version="0.17.1" targetFramework="net452" />
   <package id="Markdig.Wpf.Signed" version="0.3.0" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net452" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.0.30" targetFramework="net452" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="net452" />
   <package id="Serilog" version="2.5.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Async" version="1.1.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net452" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
+  <package id="SkiaSharp" version="1.68.1.1" targetFramework="net452" />
+  <package id="SkiaSharp.HarfBuzz" version="1.68.1.1" targetFramework="net452" />
   <package id="Splat" version="2.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net40" developmentDependency="true" />
+  <package id="Svg.Custom" version="0.1.7" targetFramework="net452" />
+  <package id="Svg.Skia" version="0.1.7" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net452" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -120,6 +120,12 @@
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.4.1.1\lib\net45\ControlzEx.dll</HintPath>
     </Reference>
+    <Reference Include="Fizzler, Version=1.2.0.0, Culture=neutral, PublicKeyToken=4ebff4844e382110, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fizzler.1.2.0\lib\netstandard1.0\Fizzler.dll</HintPath>
+    </Reference>
+    <Reference Include="HarfBuzzSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\HarfBuzzSharp.2.6.1.1\lib\net45\HarfBuzzSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LiteDB, Version=3.1.4.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.3.1.4\lib\net35\LiteDB.dll</HintPath>
     </Reference>
@@ -234,15 +240,33 @@
     <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
     </Reference>
+    <Reference Include="SkiaSharp, Version=1.68.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\SkiaSharp.1.68.1.1\lib\net45\SkiaSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SkiaSharp.HarfBuzz, Version=1.68.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\SkiaSharp.HarfBuzz.1.68.1.1\lib\net45\SkiaSharp.HarfBuzz.dll</HintPath>
+    </Reference>
     <Reference Include="Splat, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Splat.2.0.0\lib\Net45\Splat.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Svg.Custom, Version=0.0.0.0, Culture=neutral, PublicKeyToken=dafe96fe6c845a74, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.Custom.0.1.7\lib\net452\Svg.Custom.dll</HintPath>
+    </Reference>
+    <Reference Include="Svg.Skia, Version=0.1.7.0, Culture=neutral, PublicKeyToken=dafe96fe6c845a74, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.Skia.0.1.7\lib\net452\Svg.Skia.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
@@ -262,6 +286,12 @@
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
@@ -373,4 +403,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets" Condition="Exists('..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\HarfBuzzSharp.2.6.1.1\build\net45\HarfBuzzSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets'))" />
+  </Target>
+  <Import Project="..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.68.1.1\build\net45\SkiaSharp.targets')" />
 </Project>

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -132,9 +132,6 @@
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Magick.NET-Q16-AnyCPU, Version=7.5.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
-      <HintPath>..\packages\Magick.NET-Q16-AnyCPU.7.5.0\lib\net40\Magick.NET-Q16-AnyCPU.dll</HintPath>
-    </Reference>
     <Reference Include="MahApps.Metro, Version=2.0.0.0, Culture=neutral, PublicKeyToken=51482d6f650b2b3f, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.2.0.0-alpha0531\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>

--- a/Source/ChocolateyGui/app.config
+++ b/Source/ChocolateyGui/app.config
@@ -42,6 +42,14 @@
         <assemblyIdentity name="Serilog.Sinks.Console" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
     <enforceFIPSPolicy enabled="false" />
   </runtime>

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -11,7 +11,6 @@
   <package id="HarfBuzzSharp" version="2.6.1.1" targetFramework="net452" />
   <package id="LiteDB" version="3.1.4" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
-  <package id="Magick.NET-Q16-AnyCPU" version="7.5.0" targetFramework="net452" />
   <package id="MahApps.Metro" version="2.0.0-alpha0531" targetFramework="net452" />
   <package id="MahApps.Metro.IconPacks" version="3.0.0-alpha0255" targetFramework="net452" />
   <package id="Markdig.Signed" version="0.17.1" targetFramework="net452" />

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -7,6 +7,8 @@
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
   <package id="chocolatey.lib" version="0.10.15" targetFramework="net452" />
   <package id="ControlzEx" version="4.1.1" targetFramework="net452" />
+  <package id="Fizzler" version="1.2.0" targetFramework="net452" />
+  <package id="HarfBuzzSharp" version="2.6.1.1" targetFramework="net452" />
   <package id="LiteDB" version="3.1.4" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Magick.NET-Q16-AnyCPU" version="7.5.0" targetFramework="net452" />
@@ -14,9 +16,11 @@
   <package id="MahApps.Metro.IconPacks" version="3.0.0-alpha0255" targetFramework="net452" />
   <package id="Markdig.Signed" version="0.17.1" targetFramework="net452" />
   <package id="Markdig.Wpf.Signed" version="0.3.0" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net452" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.0.30" targetFramework="net452" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="net452" />
   <package id="Serilog" version="2.5.0" targetFramework="net452" />
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Async" version="1.1.0" targetFramework="net452" />
@@ -24,14 +28,23 @@
   <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
+  <package id="SkiaSharp" version="1.68.1.1" targetFramework="net452" />
+  <package id="SkiaSharp.HarfBuzz" version="1.68.1.1" targetFramework="net452" />
   <package id="Splat" version="2.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net452" developmentDependency="true" />
+  <package id="Svg.Custom" version="0.1.7" targetFramework="net452" />
+  <package id="Svg.Skia" version="0.1.7" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net452" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Using this awesome [Svg.Skia](https://github.com/wieslawsoltes/Svg.Skia) to render Svg icons correctly.

- [x] use it for Svg, Svgz
- [x] try to use SkiaSharp for all other icons too

Closes #756 

![2020-04-10_23h29_36](https://user-images.githubusercontent.com/658431/79024450-3e0a0e00-7b83-11ea-8c8f-34f54b51f284.png)

![2020-04-10_23h29_50](https://user-images.githubusercontent.com/658431/79024458-419d9500-7b83-11ea-8fd0-f294f98f4a50.png)
