### PR TITLE
Update Automapper to v7.0.1

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -52,8 +52,8 @@
     <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="AutoMapper, Version=6.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.6.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="Caliburn.Micro, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.Core.3.2.0\lib\net40\Caliburn.Micro.dll</HintPath>
@@ -196,6 +196,10 @@
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
-  <package id="AutoMapper" version="6.1.1" targetFramework="net452" />
+  <package id="AutoMapper" version="7.0.1" targetFramework="net452" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net40" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net40" requireReinstallation="true" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net40" requireReinstallation="true" />
@@ -29,4 +29,5 @@
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
+++ b/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
@@ -49,8 +49,8 @@
     <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="AutoMapper, Version=6.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.6.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="chocolatey, Version=0.10.15.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
       <HintPath>..\packages\chocolatey.lib.0.10.15\lib\chocolatey.dll</HintPath>
@@ -90,7 +90,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Source/ChocolateyGui.Common/packages.config
+++ b/Source/ChocolateyGui.Common/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
-  <package id="AutoMapper" version="6.1.1" targetFramework="net452" />
+  <package id="AutoMapper" version="7.0.1" targetFramework="net452" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
   <package id="chocolatey.lib" version="0.10.15" targetFramework="net452" />
   <package id="LiteDB" version="3.1.4" targetFramework="net452" />
@@ -16,4 +16,5 @@
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net452" developmentDependency="true" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -102,8 +102,8 @@
     <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="AutoMapper, Version=6.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.6.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
     <Reference Include="Caliburn.Micro, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.Core.3.2.0\lib\net45\Caliburn.Micro.dll</HintPath>
@@ -270,6 +270,9 @@
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
-  <package id="AutoMapper" version="6.1.1" targetFramework="net452" />
+  <package id="AutoMapper" version="7.0.1" targetFramework="net452" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net452" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
@@ -33,4 +33,5 @@
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net452" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
With this version I can fix an exception which I got at the `ChocolateyService` with the old one.

```csharp
        private static Package GetMappedPackage(GetChocolatey choco, PackageResult package, IMapper mapper, bool forceInstalled = false)
        {
            var mappedPackage = package == null ? null : mapper.Map<Package>(package.Package);
            if (mappedPackage != null)
```

System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.

v7.0.1 is also the latest possible version for .Net v4.5.2