### PR TITLE
(GH-775) Fix search at remote source

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -216,6 +216,18 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             }
         }
 
+        public bool CanSearchForPackages()
+        {
+            return HasLoaded;
+        }
+
+        public void SearchForPackages()
+        {
+#pragma warning disable 4014
+            LoadPackages(false);
+#pragma warning restore 4014
+        }
+
         public bool CanLoadRemotePackages()
         {
             return HasLoaded;

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -281,11 +281,11 @@
                              Width="200"
                              FontSize="14"
                              VerticalAlignment="Center"
-                             mah:TextBoxHelper.ButtonCommand="{commands:DataContextCommandAdapter LoadPackages, CanLoadRemotePackages}"
+                             mah:TextBoxHelper.ButtonCommand="{commands:DataContextCommandAdapter SearchForPackages, CanSearchForPackages}"
                              Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
                              Style="{DynamicResource MahApps.Styles.TextBox.Search}">
                         <TextBox.InputBindings>
-                            <KeyBinding Command="{commands:DataContextCommandAdapter LoadPackages, CanLoadRemotePackages}"
+                            <KeyBinding Command="{commands:DataContextCommandAdapter SearchForPackages, CanSearchForPackages}"
                                         Key="Return" />
                         </TextBox.InputBindings>
                     </TextBox>


### PR DESCRIPTION
Use different method names to prevent such a mistake in the future.

![image](https://user-images.githubusercontent.com/658431/82499624-43e3ff00-9af2-11ea-9226-f7078c99a14f.png)

Closes #775 
