### PR TITLE
(GH-782) Ensure correct property is used

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -347,7 +347,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         {
             try
             {
-                ListViewMode = _configService.GetAppConfiguration().DefaultToTileViewForLocalSource ? ListViewMode.Tile : ListViewMode.Standard;
+                ListViewMode = _configService.GetAppConfiguration().DefaultToTileViewForRemoteSource ? ListViewMode.Tile : ListViewMode.Standard;
                 ShowAdditionalPackageInformation = _configService.GetAppConfiguration().ShowAdditionalPackageInformation;
 
                 Observable.FromEventPattern<EventArgs>(_configService, "SettingsChanged")

--- a/docs/input/docs/business_features/index.cshtml
+++ b/docs/input/docs/business_features/index.cshtml
@@ -1,5 +1,5 @@
 ---
-Order: 50
+Order: 60
 Title: Business Features
 Description: Information about additional features that can be added using Chocolatye GUI for Business
 ---

--- a/docs/input/docs/commands/index.cshtml
+++ b/docs/input/docs/commands/index.cshtml
@@ -1,5 +1,5 @@
 ---
-Order: 30
+Order: 40
 Description: Information about the various commands which can be used with Chocolatey GUI
 ---
 

--- a/docs/input/docs/configuration/index.cshtml
+++ b/docs/input/docs/configuration/index.cshtml
@@ -1,5 +1,5 @@
 ---
-Order: 40
+Order: 50
 Description: How to configure Chocolatey GUI
 ---
 

--- a/docs/input/docs/installation/chocolatey_gui.md
+++ b/docs/input/docs/installation/chocolatey_gui.md
@@ -4,4 +4,29 @@ Title: Install Chocolatey GUI
 Description: Instructions on how to install Chocolatey GUI
 ---
 
-Put stuff here...
+The easiest way to install Chocolatey GUI is to use Chocolatey.  Use the
+following command to install the latest version of Chocolatey GUI:
+
+```powershell
+choco install chocolateygui
+```
+
+## Upgrading Chocolatey GUI
+
+If you already have Chocolatey GUI installed, you can upgrade to the latest
+version using the following command:
+
+```powershell
+choco upgrade chocolateygui
+```
+
+## Installing Beta Versions of Chocolatey GUI
+
+Each time a commit is made into the Chocolatey GUI repository, a build is
+performed, and the output is pushed to the Chocolatey GUI MyGet feed.  If you
+are interested in using the very latest version of Chocolatey GUI, you can use
+the following command to install it:
+
+```powershell
+choco upgrade chocolateygui --pre --source="'https://myget.org/f/chocolateygui
+```

--- a/docs/input/docs/localization.md
+++ b/docs/input/docs/localization.md
@@ -1,5 +1,5 @@
 ---
-Order: 60
+Order: 70
 Title: Localization
 Description: Localization in Chocolatey GUI
 ---

--- a/docs/input/docs/uninstallation/chocolatey_gui.md
+++ b/docs/input/docs/uninstallation/chocolatey_gui.md
@@ -1,0 +1,7 @@
+---
+Order: 10
+Title: Uninstall Chocolatey GUI
+Description: Instructions on how to uninstall Chocolatey GUI
+---
+
+Put stuff here...

--- a/docs/input/docs/uninstallation/chocolatey_gui_extension.md
+++ b/docs/input/docs/uninstallation/chocolatey_gui_extension.md
@@ -1,0 +1,7 @@
+---
+Order: 20
+Title: Uninstall Chocolatey GUI Extension
+Description: Instructions on how to uninstall the Chocolatey GUI Extension
+---
+
+Put stuff here...

--- a/docs/input/docs/uninstallation/index.cshtml
+++ b/docs/input/docs/uninstallation/index.cshtml
@@ -1,0 +1,9 @@
+---
+Order: 20
+Title: Uninstallation
+Description: Information on how to uninstall Chocolatey GUI
+---
+
+<p>Put stuff here...</p>
+
+@Html.Partial("_ChildPages")

--- a/docs/input/docs/user_interface/index.cshtml
+++ b/docs/input/docs/user_interface/index.cshtml
@@ -1,5 +1,5 @@
 ---
-Order: 20
+Order: 30
 Title: User Interface
 Description: How to use the Chocolatey GUI User Interface
 ---


### PR DESCRIPTION
When setting up the RemoteSourceViewModel, the DefaultToTileViewForLocalSource was
being used, where the DefaultToTileViewForRemoteSource used be getting used instead.

Fixes #782 