### PR TITLE
(#757) Allow buttons to be enabled/disabled

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -208,6 +208,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Utilities\ToolTipBehavior.cs" />
     <Compile Include="Bootstrapper.cs" />
     <Compile Include="Commands\CommandExecutionManager.cs" />
     <Compile Include="Commands\DataContextCommandAdapter.cs" />

--- a/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Resources/Controls.xaml
@@ -10,6 +10,8 @@
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                     xmlns:theming="clr-namespace:ChocolateyGui.Common.Windows.Theming"
+                    xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+                    xmlns:utilities="clr-namespace:ChocolateyGui.Common.Windows.Utilities"
                     mc:Ignorable="d">
 
     <ResourceDictionary.MergedDictionaries>
@@ -451,31 +453,73 @@
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuPin}"
                   Icon="{iconPacks:Modern Kind=Pin}"
                   Command="{commands:DataContextCommandAdapter Pin}"
-                  Visibility="{Binding CanPin, Converter={StaticResource BooleanToVisibility}}" />
+                  IsEnabled="{Binding IsPinAllowed}"
+                  Visibility="{Binding CanPin, Converter={StaticResource BooleanToVisibility}}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationPin}"
+                                           IsFeatureEnabled="{Binding IsPinAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUnpin}"
                   Icon="{iconPacks:Modern Kind=PinRemove}"
                   Command="{commands:DataContextCommandAdapter Unpin}"
-                  Visibility="{Binding CanUnpin, Converter={StaticResource BooleanToVisibility}}" />
+                  IsEnabled="{Binding IsUnpinAllowed}"
+                  Visibility="{Binding CanUnpin, Converter={StaticResource BooleanToVisibility}}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUnpin}"
+                                           IsFeatureEnabled="{Binding IsUnpinAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuDetails}"
                   Icon="{iconPacks:BoxIcons Kind=RegularInfoCircle}"
                   Command="{commands:DataContextCommandAdapter ViewDetails}" />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUpdate}"
                   Icon="{iconPacks:Entypo Kind=Cycle}"
+                  IsEnabled="{Binding IsUpgradeAllowed}"
                   Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Update}" />
+                  Command="{commands:DataContextCommandAdapter Update}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUpgrade}"
+                                           IsFeatureEnabled="{Binding IsUpgradeAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
         <Separator />
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuInstall}"
                   Icon="{iconPacks:Entypo Kind=Install}"
+                  IsEnabled="{Binding IsInstallAllowed}"
                   Visibility="{Binding CanInstall, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Install}" />
+                  Command="{commands:DataContextCommandAdapter Install}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationInstall}"
+                                           IsFeatureEnabled="{Binding IsInstallAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuReinstall}"
                   Icon="{iconPacks:Entypo Kind=Cw}"
+                  IsEnabled="{Binding IsReinstallAllowed}"
                   Visibility="{Binding CanReinstall, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Reinstall}" />
+                  Command="{commands:DataContextCommandAdapter Reinstall}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationReinstall}"
+                                           IsFeatureEnabled="{Binding IsReinstallAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
         <MenuItem Header="{x:Static properties:Resources.Controls_PackagesContextMenuUninstall}"
                   Icon="{iconPacks:Entypo Kind=Uninstall}"
+                  IsEnabled="{Binding IsUninstallAllowed}"
                   Visibility="{Binding CanUninstall, Converter={StaticResource BooleanToVisibility}}"
-                  Command="{commands:DataContextCommandAdapter Uninstall}" />
+                  Command="{commands:DataContextCommandAdapter Uninstall}">
+            <b:Interaction.Behaviors>
+                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUninstall}"
+                                           IsFeatureEnabled="{Binding IsUninstallAllowed, Mode=OneWay}"
+                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+            </b:Interaction.Behaviors>
+        </MenuItem>
     </ContextMenu>
 
     <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource {x:Type DataGrid}}">

--- a/Source/ChocolateyGui.Common.Windows/Utilities/ToolTipBehavior.cs
+++ b/Source/ChocolateyGui.Common.Windows/Utilities/ToolTipBehavior.cs
@@ -1,0 +1,120 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ToolTipBehavior.cs" company="Chocolatey">
+//   Copyright 2017 - Present Chocolatey Software, LLC
+//   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.Xaml.Behaviors;
+
+namespace ChocolateyGui.Common.Windows.Utilities
+{
+    public class ToolTipBehavior : Behavior<FrameworkElement>
+    {
+        public static readonly DependencyProperty EnabledToolTipProperty
+            = DependencyProperty.Register(
+                nameof(EnabledToolTip),
+                typeof(object),
+                typeof(ToolTipBehavior),
+                new PropertyMetadata(default, OnToolTipPropertyChanged));
+
+        public static readonly DependencyProperty DisabledToolTipProperty
+            = DependencyProperty.Register(
+                nameof(DisabledToolTip),
+                typeof(object),
+                typeof(ToolTipBehavior),
+                new PropertyMetadata(default, OnToolTipPropertyChanged));
+
+        public static readonly DependencyProperty IsFeatureEnabledProperty
+            = DependencyProperty.Register(
+                nameof(IsFeatureEnabled),
+                typeof(bool),
+                typeof(ToolTipBehavior),
+                new PropertyMetadata(true, OnToolTipPropertyChanged));
+
+        public static readonly DependencyProperty DisabledFeatureToolTipProperty
+            = DependencyProperty.Register(
+                nameof(DisabledFeatureToolTip),
+                typeof(object),
+                typeof(ToolTipBehavior),
+                new PropertyMetadata(default, OnToolTipPropertyChanged));
+
+        public object EnabledToolTip
+        {
+            get { return GetValue(EnabledToolTipProperty); }
+            set { SetValue(EnabledToolTipProperty, value); }
+        }
+
+        public object DisabledToolTip
+        {
+            get { return GetValue(DisabledToolTipProperty); }
+            set { SetValue(DisabledToolTipProperty, value); }
+        }
+
+        public bool IsFeatureEnabled
+        {
+            get { return (bool)GetValue(IsFeatureEnabledProperty); }
+            set { SetValue(IsFeatureEnabledProperty, value); }
+        }
+
+        public object DisabledFeatureToolTip
+        {
+            get { return GetValue(DisabledFeatureToolTipProperty); }
+            set { SetValue(DisabledFeatureToolTipProperty, value); }
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            AssociatedObject.SetCurrentValue(ToolTipService.ShowOnDisabledProperty, true);
+
+            SetTheToolTip();
+
+            AssociatedObject.IsEnabledChanged += AssociatedObject_IsEnabledChanged;
+        }
+
+        protected override void OnDetaching()
+        {
+            AssociatedObject.IsEnabledChanged -= AssociatedObject_IsEnabledChanged;
+
+            base.OnDetaching();
+        }
+
+        private static void OnToolTipPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue != e.OldValue)
+            {
+                (d as ToolTipBehavior)?.SetTheToolTip();
+            }
+        }
+
+        private void AssociatedObject_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            SetTheToolTip();
+        }
+
+        private void SetTheToolTip()
+        {
+            if (AssociatedObject is null)
+            {
+                return;
+            }
+
+            if (!AssociatedObject.IsEnabled && !IsFeatureEnabled)
+            {
+                AssociatedObject.SetCurrentValue(FrameworkElement.ToolTipProperty, DisabledFeatureToolTip);
+            }
+            else if (AssociatedObject.IsEnabled)
+            {
+                AssociatedObject.SetCurrentValue(FrameworkElement.ToolTipProperty, EnabledToolTip);
+            }
+            else
+            {
+                AssociatedObject.SetCurrentValue(FrameworkElement.ToolTipProperty, DisabledToolTip);
+            }
+        }
+    }
+}

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -148,17 +148,29 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             set { SetPropertyValue(ref _authors, value); }
         }
 
-        public bool CanInstall => _allowedCommandsService.IsInstallCommandAllowed && !IsInstalled;
+        public bool CanInstall => !IsInstalled;
 
-        public bool CanReinstall => _allowedCommandsService.IsInstallCommandAllowed && IsInstalled;
+        public bool IsInstallAllowed => _allowedCommandsService.IsInstallCommandAllowed;
 
-        public bool CanUninstall => _allowedCommandsService.IsUninstallCommandAllowed && IsInstalled;
+        public bool CanReinstall => IsInstalled;
 
-        public bool CanUpdate => _allowedCommandsService.IsUpgradeCommandAllowed && IsInstalled && !IsPinned && !IsSideBySide && LatestVersion != null && LatestVersion > Version;
+        public bool IsReinstallAllowed => _allowedCommandsService.IsInstallCommandAllowed;
 
-        public bool CanPin => _allowedCommandsService.IsPinCommandAllowed && !IsPinned && IsInstalled;
+        public bool CanUninstall => IsInstalled;
 
-        public bool CanUnpin => _allowedCommandsService.IsPinCommandAllowed && IsPinned && IsInstalled;
+        public bool IsUninstallAllowed => _allowedCommandsService.IsUninstallCommandAllowed;
+
+        public bool CanUpdate => IsInstalled && !IsPinned && !IsSideBySide && !IsLatestVersion;
+
+        public bool IsUpgradeAllowed => _allowedCommandsService.IsUpgradeCommandAllowed;
+
+        public bool CanPin => !IsPinned && IsInstalled;
+
+        public bool IsPinAllowed => _allowedCommandsService.IsPinCommandAllowed;
+
+        public bool CanUnpin => IsPinned && IsInstalled;
+
+        public bool IsUnpinAllowed => _allowedCommandsService.IsPinCommandAllowed;
 
         public string Copyright
         {
@@ -215,8 +227,18 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         public bool IsInstalled
         {
-            get { return _isInstalled; }
-            set { SetPropertyValue(ref _isInstalled, value); }
+            get
+            {
+                return _isInstalled;
+            }
+
+            set
+            {
+                if (SetPropertyValue(ref _isInstalled, value))
+                {
+                    NotifyPropertyChanged(nameof(CanUpdate));
+                }
+            }
         }
 
         public bool IsPinned
@@ -253,8 +275,18 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         public bool IsLatestVersion
         {
-            get { return _isLatestVersion; }
-            set { SetPropertyValue(ref _isLatestVersion, value); }
+            get
+            {
+                return _isLatestVersion;
+            }
+
+            set
+            {
+                if (SetPropertyValue(ref _isLatestVersion, value))
+                {
+                    NotifyPropertyChanged(nameof(CanUpdate));
+                }
+            }
         }
 
         public bool IsPrerelease

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/LocalSourceViewModel.cs
@@ -42,6 +42,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         private readonly IChocolateyGuiCacheService _chocolateyGuiCacheService;
         private readonly IProgressService _progressService;
         private readonly IConfigService _configService;
+        private readonly IAllowedCommandsService _allowedCommandsService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IMapper _mapper;
         private bool _exportAll = true;
@@ -64,6 +65,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             IPersistenceService persistenceService,
             IChocolateyGuiCacheService chocolateyGuiCacheService,
             IConfigService configService,
+            IAllowedCommandsService allowedCommandsService,
             IEventAggregator eventAggregator,
             string displayName,
             IMapper mapper)
@@ -73,6 +75,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             _persistenceService = persistenceService;
             _chocolateyGuiCacheService = chocolateyGuiCacheService;
             _configService = configService;
+            _allowedCommandsService = allowedCommandsService;
 
             DisplayName = displayName;
 
@@ -165,9 +168,14 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             set { this.SetPropertyValue(ref _firstLoadIncomplete, value); }
         }
 
+        public bool IsUpgradeAllowed
+        {
+            get { return _allowedCommandsService.IsUpgradeCommandAllowed; }
+        }
+
         public bool CanUpdateAll()
         {
-            return Packages.Any(p => p.CanUpdate);
+            return Packages.Any(p => p.CanUpdate) && _allowedCommandsService.IsUpgradeCommandAllowed;
         }
 
         public async void UpdateAll()

--- a/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
@@ -212,9 +212,16 @@
                     <iconPacks:PackIconFontAwesome Kind="SyncSolid" />
                 </Button>
                 <Button Command="{commands:DataContextCommandAdapter UpdateAll, CanUpdateAll}"
-                        ToolTipService.ShowOnDisabled="True"
                         VerticalAlignment="Center"
-                        Style="{DynamicResource IconFlatButtonStyle}" ToolTip="{x:Static properties:Resources.LocalSourceView_ButtonUpdateAll}" Margin="2,0,2,0">
+                        Style="{DynamicResource IconFlatButtonStyle}"
+                        ToolTip=""
+                        Margin="2,0,2,0">
+                    <i:Interaction.Behaviors>
+                        <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.LocalSourceView_ButtonUpdateAll}"
+                                                   DisabledToolTip="{x:Static properties:Resources.LocalSourceView_ButtonUpdateAllDisabled}"
+                                                   IsFeatureEnabled="{Binding IsUpgradeAllowed, Mode=OneWay}"
+                                                   DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                    </i:Interaction.Behaviors>
                     <StackPanel Orientation="Horizontal">
                         <iconPacks:PackIconFontAwesome Kind="SyncSolid" />
                         <iconPacks:PackIconFontAwesome Kind="AsteriskSolid" Margin="2 0 0 0" />

--- a/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
@@ -64,6 +64,11 @@
                                 Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=True}">
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Install}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationInstall}"
+                                                           IsFeatureEnabled="{Binding IsInstallAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconEntypo Kind="Install" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonInstall}" FontSize="16"/>
@@ -74,7 +79,13 @@
                                 Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}}">
                         <Button Padding="10" Margin="5 0"
                                 Command="{commands:DataContextCommandAdapter Pin}"
+                                IsEnabled="{Binding IsPinAllowed}"
                                 Visibility="{Binding CanPin, Converter={StaticResource BooleanToVisibility}}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationPin}"
+                                                           IsFeatureEnabled="{Binding IsPinAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconModern Kind="Pin" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonPin}" FontSize="16"/>
@@ -82,7 +93,13 @@
                         </Button>
                         <Button Padding="10" Margin="5 0"
                                 Command="{commands:DataContextCommandAdapter Unpin}"
+                                IsEnabled="{Binding IsUnpinAllowed}"
                                 Visibility="{Binding CanUnpin, Converter={StaticResource BooleanToVisibility}}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUnpin}"
+                                                           IsFeatureEnabled="{Binding IsUnpinAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconModern Kind="PinRemove" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUnpin}" FontSize="16"/>
@@ -90,7 +107,13 @@
                         </Button>
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Reinstall}"
+                            IsEnabled="{Binding IsReinstallAllowed}"
                             Visibility="{Binding CanReinstall, Converter={StaticResource BooleanToVisibility}}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationReinstall}"
+                                                           IsFeatureEnabled="{Binding IsReinstallAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconEntypo Kind="Cw" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonReinstall}" FontSize="16"/>
@@ -98,7 +121,13 @@
                         </Button>
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Uninstall}"
+                            IsEnabled="{Binding IsUninstallAllowed}"
                             Visibility="{Binding CanUninstall, Converter={StaticResource BooleanToVisibility}}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUninstall}"
+                                                           IsFeatureEnabled="{Binding IsUninstallAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconEntypo Kind="Uninstall" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUninstall}" FontSize="16"/>
@@ -106,7 +135,13 @@
                         </Button>
                         <Button Padding="10" Margin="5 0"
                             Command="{commands:DataContextCommandAdapter Update}"
+                            IsEnabled="{Binding IsUpgradeAllowed}"
                             Visibility="{Binding CanUpdate, Converter={StaticResource BooleanToVisibility}}">
+                            <i:Interaction.Behaviors>
+                                <utilities:ToolTipBehavior EnabledToolTip="{x:Static properties:Resources.Application_OperationUpgrade}"
+                                                           IsFeatureEnabled="{Binding IsUpgradeAllowed, Mode=OneWay}"
+                                                           DisabledFeatureToolTip="{x:Static properties:Resources.Application_OperationNotAllowed}" />
+                            </i:Interaction.Behaviors>
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconEntypo Kind="Cycle" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{x:Static properties:Resources.PackageView_ButtonUpdate}" FontSize="16"/>

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -115,6 +115,73 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Install the most recent package version.
+        /// </summary>
+        public static string Application_OperationInstall {
+            get {
+                return ResourceManager.GetString("Application_OperationInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation is not available due to the global setting of:
+        ///
+        ///backgroundServiceAllowedCommands configuration option
+        ///
+        ///Please contact your System Administrator to enable this operation..
+        /// </summary>
+        public static string Application_OperationNotAllowed {
+            get {
+                return ResourceManager.GetString("Application_OperationNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pin package to currently installed package version.
+        /// </summary>
+        public static string Application_OperationPin {
+            get {
+                return ResourceManager.GetString("Application_OperationPin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reinstall the most recent package version.
+        /// </summary>
+        public static string Application_OperationReinstall {
+            get {
+                return ResourceManager.GetString("Application_OperationReinstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall the currently installed package version.
+        /// </summary>
+        public static string Application_OperationUninstall {
+            get {
+                return ResourceManager.GetString("Application_OperationUninstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unpin from the currently installed package version.
+        /// </summary>
+        public static string Application_OperationUnpin {
+            get {
+                return ResourceManager.GetString("Application_OperationUnpin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update the currently installed package version.
+        /// </summary>
+        public static string Application_OperationUpgrade {
+            get {
+                return ResourceManager.GetString("Application_OperationUpgrade", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to serialize Outdated Packages Cache file..
         /// </summary>
         public static string Application_OutdatedPackagesError {
@@ -940,6 +1007,15 @@ namespace ChocolateyGui.Common.Properties {
         public static string LocalSourceView_ButtonUpdateAll {
             get {
                 return ResourceManager.GetString("LocalSourceView_ButtonUpdateAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No packages need to be updated.
+        /// </summary>
+        public static string LocalSourceView_ButtonUpdateAllDisabled {
+            get {
+                return ResourceManager.GetString("LocalSourceView_ButtonUpdateAllDisabled", resourceCulture);
             }
         }
         

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1012,4 +1012,32 @@ Normal:
   <data name="SettingsView_ToggleDefaultToDarkMode" xml:space="preserve">
     <value>Default to dark mode. It is still possible to switch during use.</value>
   </data>
+  <data name="Application_OperationInstall" xml:space="preserve">
+    <value>Install the most recent package version</value>
+  </data>
+  <data name="Application_OperationNotAllowed" xml:space="preserve">
+    <value>This operation is not available due to the global setting of:
+
+backgroundServiceAllowedCommands configuration option
+
+Please contact your System Administrator to enable this operation.</value>
+  </data>
+  <data name="Application_OperationPin" xml:space="preserve">
+    <value>Pin package to currently installed package version</value>
+  </data>
+  <data name="Application_OperationReinstall" xml:space="preserve">
+    <value>Reinstall the most recent package version</value>
+  </data>
+  <data name="Application_OperationUninstall" xml:space="preserve">
+    <value>Uninstall the currently installed package version</value>
+  </data>
+  <data name="Application_OperationUnpin" xml:space="preserve">
+    <value>Unpin from the currently installed package version</value>
+  </data>
+  <data name="Application_OperationUpgrade" xml:space="preserve">
+    <value>Update the currently installed package version</value>
+  </data>
+  <data name="LocalSourceView_ButtonUpdateAllDisabled" xml:space="preserve">
+    <value>No packages need to be updated</value>
+  </data>
 </root>


### PR DESCRIPTION
The decision was taken to allow a button to be enabled/disabled based on
current Chocolatey configuration (mainly when running in background
service mode). To allow for this, whilst still allowing a button to be
enabled/disabled based on application logic, a new behavior was
introduced to encapsulate this logic.

This will allow the Chocolatey GUI Licensed Extension to override the
AllowedCommandsService, to control which operations should be enabled
and disabled, based on the background service configuration.

Relates to #757 