### PR TITLE
Fix logic of IsShowOnlyPackagesWithUpdateEnabled when PreventAutomatedOutdatedPackages is not set

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ViewModels/LocalSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/LocalSourceViewModel.cs
@@ -480,7 +480,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                 // outdated packages. We should only enable the checkbox here when: (or)
                 // 1. the "Prevent Automated Outdated Packages Check" is disabled
                 // 2. forced a check for outdated packages.
-                IsShowOnlyPackagesWithUpdateEnabled = forceCheckForOutdated || (!_configService.GetEffectiveConfiguration().PreventAutomatedOutdatedPackagesCheck ?? false);
+                IsShowOnlyPackagesWithUpdateEnabled = forceCheckForOutdated || !(_configService.GetEffectiveConfiguration().PreventAutomatedOutdatedPackagesCheck ?? false);
 
                 // Force invalidating the command stuff.
                 // This helps us to prevent disabled buttons after executing this routine.


### PR DESCRIPTION
The IsShowOnlyPackagesWithUpdateEnabled will be false if the PreventAutomatedOutdatedPackagesCheck is not set. So you will not see any updated packages without forcing the search for it.

This PR fix this issue.

Closes #821 
