### PR TITLE
(#786) Add confirmation for destructive operations

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Services/IProgressService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/IProgressService.cs
@@ -27,6 +27,8 @@ namespace ChocolateyGui.Common.Windows.Services
 
         Task<MessageDialogResult> ShowMessageAsync(string title, string message);
 
+        Task<MessageDialogResult> ShowConfirmationMessageAsync(string title, string message);
+
         Task StartLoading(string title = null, bool isCancelable = false);
 
         Task StopLoading();

--- a/Source/ChocolateyGui.Common.Windows/Services/ProgressService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ProgressService.cs
@@ -96,6 +96,27 @@ namespace ChocolateyGui.Common.Windows.Services
             }
         }
 
+        public async Task<MessageDialogResult> ShowConfirmationMessageAsync(string title, string message)
+        {
+            using (await _lock.EnterAsync())
+            {
+                if (ShellView != null)
+                {
+                    var dialogSettings = new MetroDialogSettings
+                    {
+                        AffirmativeButtonText = Resources.Dialog_Yes,
+                        NegativeButtonText = Resources.Dialog_No
+                    };
+
+                    return await RunOnUIAsync(() => ShellView.ShowMessageAsync(title, message, MessageDialogStyle.AffirmativeAndNegative, dialogSettings));
+                }
+
+                return MessageBox.Show(message, title, MessageBoxButton.YesNo) == MessageBoxResult.Yes
+                           ? MessageDialogResult.Affirmative
+                           : MessageDialogResult.Negative;
+            }
+        }
+
         public async Task StartLoading(string title = null, bool isCancelable = false)
         {
             using (await _lock.EnterAsync())

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -750,11 +750,29 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This action will attempt to reinstall the &apos;{0}&apos; package.  Are you sure you want to proceed?.
+        /// </summary>
+        public static string Dialog_AreYouSureReinstallMessage {
+            get {
+                return ResourceManager.GetString("Dialog_AreYouSureReinstallMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure?.
         /// </summary>
         public static string Dialog_AreYouSureTitle {
             get {
                 return ResourceManager.GetString("Dialog_AreYouSureTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This action will attempt to uninstall the &apos;{0}&apos; package. Are you sure you want to proceed?.
+        /// </summary>
+        public static string Dialog_AreYouSureUninstallMessage {
+            get {
+                return ResourceManager.GetString("Dialog_AreYouSureUninstallMessage", resourceCulture);
             }
         }
         

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1047,4 +1047,12 @@ Please contact your System Administrator to enable this operation.</value>
   <data name="Dialog_AreYouSureUpdateAllMessage" xml:space="preserve">
     <value>This action, depending on the number of currently outdated packages, may take a long time to complete. Are you sure that you want to continue?</value>
   </data>
+  <data name="Dialog_AreYouSureReinstallMessage" xml:space="preserve">
+    <value>This action will attempt to reinstall the '{0}' package.  Are you sure you want to proceed?</value>
+    <comment>{0} = The id of the package that is going to be reinstalled</comment>
+  </data>
+  <data name="Dialog_AreYouSureUninstallMessage" xml:space="preserve">
+    <value>This action will attempt to uninstall the '{0}' package. Are you sure you want to proceed?</value>
+    <comment>{0} = The id of the package that is going to be uninstalled</comment>
+  </data>
 </root>


### PR DESCRIPTION
A confirmation dialog is being added to the reinstall and uninstall
operations since these can be harmful operations to the system.

Fixes #786 