### PR TITLE
(#842) added a check for NET Framework 4.8

### DIFF
--- a/Source/ChocolateyGui.Install/ChocolateyGui.Install.wixproj
+++ b/Source/ChocolateyGui.Install/ChocolateyGui.Install.wixproj
@@ -40,6 +40,7 @@
   	<DefineConstants>$(DefineConstants);GuiProjectFolder=$(_GuiProjectFolder);GuiTargetDir=$(_GuiTargetDir);GuiCliProjectFolder=$(_GuiCliProjectFolder);GuiCliTargetDir=$(_GuiCliTargetDir)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="NetFx48.wxs" />
     <Compile Include="Product.wxs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/ChocolateyGui.Install/NetFx48.wxs
+++ b/Source/ChocolateyGui.Install/NetFx48.wxs
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<!--
+
+This file is a part of https://github.com/wixtoolset/wix3/blob/a80818accbf6ee5681fa01bb1da538c7ae5a9b09/src/ext/NetFxExtension/wixlib/NetFx48.wxs
+which is licensed in the wix3 project under the Microsoft Reciprocal License (MS-RL). See https://github.com/wixtoolset/wix3/blob/a80818accbf6ee5681fa01bb1da538c7ae5a9b09/LICENSE.TXT
+
+This file can be removed, once a Wix version GREATER THAN v3.14.0.4118 ís used to build.
+
+-->
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <?define NetFx48MinRelease = 528040 ?>
+
+  <Fragment>
+    <PropertyRef Id="WIXNETFX4RELEASEINSTALLED" />
+    <Property Id="WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED" Secure="yes" />
+    <SetProperty Id="WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED" Value="1" After="AppSearch">
+      WIXNETFX4RELEASEINSTALLED >= "#$(var.NetFx48MinRelease)"
+    </SetProperty>
+  </Fragment>
+</Wix>

--- a/Source/ChocolateyGui.Install/Product.wxs
+++ b/Source/ChocolateyGui.Install/Product.wxs
@@ -11,12 +11,12 @@
   <Product Id="*" Name="$(var.ProductName)" Language="$(var.Language)" Version="$(var.Version)" Manufacturer="$(var.Manufacturer)" UpgradeCode="f8164f91-fa5c-4789-b68d-9beb5b146155">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
 
-    <PropertyRef Id="WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED" />
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED" />
     <SetProperty Id="CHOCOLATEY_INSTALL" Value="$(env.ChocolateyInstall)" Before="LaunchConditions" Sequence="first"  />
 
 
-    <Condition Message="This application requires .NET Framework 4.5.2. Please install the .NET 4.5.2 Framework then run this installer again.">
-      <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED]]>
+    <Condition Message="This application requires .NET Framework 4.8. Please install the .NET 4.8 Framework then run this installer again.">
+      <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED]]>
     </Condition>
 
     <Condition Message="This application only runs in Windows 7 SP1 or later.">


### PR DESCRIPTION
in the installer.

While the code I used to implement the check is part of multiple comments/discussions I decided to copy from the "original", so I added an extra comment for the license of the original (MS-RL).
The whole file `NetFx48.wsx` can be removed, once the Wix version is bumped to one greater than v3.14.0.4118.

fixes #842 