### PR TITLE
(#697) Update Chocolatey API calling

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
+++ b/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
@@ -112,7 +112,7 @@ namespace ChocolateyGui.Common.Windows
             {
                 // Do not remove! Load Chocolatey once so all config gets set
                 // properly for future calls
-                var choco = Lets.GetChocolatey();
+                var choco = Lets.GetChocolatey(initializeLogging: false);
 
                 Mapper.Initialize(config =>
                 {

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright company="Chocolatey" file="ChocolateyService.cs">
 //   Copyright 2017 - Present Chocolatey Software, LLC
 //   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
@@ -54,7 +54,7 @@ namespace ChocolateyGui.Common.Windows.Services
             _xmlService = xmlService;
             _fileSystem = fileSystem;
             _configService = configService;
-            _choco = Lets.GetChocolatey().SetCustomLogging(new SerilogLogger(Logger, _progressService));
+            _choco = Lets.GetChocolatey(initializeLogging: false).SetCustomLogging(new SerilogLogger(Logger, _progressService), logExistingMessages: false, addToExistingLoggers: true);
 
             _localAppDataPath = _fileSystem.combine_paths(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "Chocolatey GUI");
         }
@@ -119,7 +119,7 @@ namespace ChocolateyGui.Common.Windows.Services
             }
             else
             {
-                var choco = Lets.GetChocolatey();
+                var choco = Lets.GetChocolatey(initializeLogging: false);
                 choco.Set(
                     config =>
                     {
@@ -172,7 +172,7 @@ namespace ChocolateyGui.Common.Windows.Services
             using (await Lock.WriteLockAsync())
             {
                 var logger = new SerilogLogger(Logger, _progressService);
-                var choco = Lets.GetChocolatey().SetCustomLogging(logger);
+                var choco = Lets.GetChocolatey(initializeLogging: false).SetCustomLogging(logger, logExistingMessages: false, addToExistingLoggers: true);
                 choco.Set(
                     config =>
                         {
@@ -341,7 +341,7 @@ namespace ChocolateyGui.Common.Windows.Services
             using (await Lock.WriteLockAsync())
             {
                 var logger = new SerilogLogger(Logger, _progressService);
-                var choco = Lets.GetChocolatey().SetCustomLogging(logger);
+                var choco = Lets.GetChocolatey(initializeLogging: false).SetCustomLogging(logger, logExistingMessages: false, addToExistingLoggers: true);
                 choco.Set(
                     config =>
                         {
@@ -364,7 +364,7 @@ namespace ChocolateyGui.Common.Windows.Services
             using (await Lock.WriteLockAsync())
             {
                 var logger = new SerilogLogger(Logger, _progressService);
-                var choco = Lets.GetChocolatey().SetCustomLogging(logger);
+                var choco = Lets.GetChocolatey(initializeLogging: false).SetCustomLogging(logger, logExistingMessages: false, addToExistingLoggers: true);
                 choco.Set(
                     config =>
                         {

--- a/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
+++ b/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
@@ -65,7 +65,7 @@ namespace ChocolateyGui.Common.Windows.Startup
 
             builder.RegisterType<PackageViewModel>().As<IPackageViewModel>();
 
-            var choco = Lets.GetChocolatey();
+            var choco = Lets.GetChocolatey(initializeLogging: true);
             builder.RegisterInstance(choco.Container().GetInstance<IChocolateyConfigSettingsService>())
                 .As<IChocolateyConfigSettingsService>().SingleInstance();
             builder.RegisterInstance(choco.Container().GetInstance<IXmlService>())

--- a/Source/ChocolateyGuiCli/Startup/ChocolateyGuiCliModule.cs
+++ b/Source/ChocolateyGuiCli/Startup/ChocolateyGuiCliModule.cs
@@ -35,7 +35,7 @@ namespace ChocolateyGuiCli.Startup
             builder.RegisterType<ChocolateyConfigurationProvider>().As<IChocolateyConfigurationProvider>().SingleInstance();
             builder.RegisterType<DotNetFileSystem>().As<chocolatey.infrastructure.filesystem.IFileSystem>().SingleInstance();
 
-            var choco = Lets.GetChocolatey();
+            var choco = Lets.GetChocolatey(initializeLogging: false);
             builder.RegisterInstance(choco.Container().GetInstance<IChocolateyConfigSettingsService>())
                 .As<IChocolateyConfigSettingsService>().SingleInstance();
             builder.RegisterInstance(choco.Container().GetInstance<IXmlService>())


### PR DESCRIPTION
This commit makes changes to how the Chocolatey API is being called,
which then allows the original logging that Chocolatey implements
to still happen when we add our own Serilog logger.

This change depends on a new change in the Chocolatey codebase,
and a new release of the program.

fixes #697

Heavily dependent on Chocolatey PR https://github.com/chocolatey/choco/pull/2295

Do Not Merge until a new release of Chocolatey with the PR mentioned is released.