### PR TITLE
(#904) Wrap MessageBoxes with a hidden window

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
+++ b/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
@@ -24,6 +24,7 @@ using ChocolateyGui.Common.Startup;
 using ChocolateyGui.Common.Utilities;
 using ChocolateyGui.Common.ViewModels.Items;
 using ChocolateyGui.Common.Windows.Startup;
+using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.ViewModels;
 using LiteDB;
 using Serilog;
@@ -135,7 +136,7 @@ namespace ChocolateyGui.Common.Windows
             }
             catch (Exception ex)
             {
-                MessageBox.Show(string.Format(Resources.Fatal_Startup_Error_Formatted, ex.Message));
+                ChocolateyMessageBox.Show(string.Format(Resources.Fatal_Startup_Error_Formatted, ex.Message));
                 Logger.Fatal(ex, Resources.Fatal_Startup_Error);
                 await OnExitAsync();
             }
@@ -192,7 +193,7 @@ namespace ChocolateyGui.Common.Windows
                     return;
                 }
 
-                MessageBox.Show(
+                ChocolateyMessageBox.Show(
                     e.ExceptionObject.ToString(),
                     Resources.Bootstrapper_UnhandledException,
                     MessageBoxButton.OK,

--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Controls\Dialogs\IClosableChildWindow.cs" />
     <Compile Include="Services\DialogService.cs" />
     <Compile Include="Services\IDialogService.cs" />
+    <Compile Include="Utilities\ChocolateyMessageBox.cs" />
     <Compile Include="Utilities\ToolTipBehavior.cs" />
     <Compile Include="Bootstrapper.cs" />
     <Compile Include="Commands\CommandExecutionManager.cs" />

--- a/Source/ChocolateyGui.Common.Windows/Services/DialogService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/DialogService.cs
@@ -12,6 +12,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using ChocolateyGui.Common.Properties;
 using ChocolateyGui.Common.Windows.Controls.Dialogs;
+using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.Views;
 using ControlzEx.Theming;
 using MahApps.Metro.Controls.Dialogs;
@@ -48,7 +49,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     return await ShellView.ShowMessageAsync(title, message, MessageDialogStyle.Affirmative, dialogSettings);
                 }
 
-                return MessageBox.Show(message, title) == MessageBoxResult.OK
+                return ChocolateyMessageBox.Show(message, title) == MessageBoxResult.OK
                     ? MessageDialogResult.Affirmative
                     : MessageDialogResult.Negative;
             }
@@ -70,7 +71,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     return await ShellView.ShowMessageAsync(title, message, MessageDialogStyle.AffirmativeAndNegative, dialogSettings);
                 }
 
-                return MessageBox.Show(message, title, MessageBoxButton.YesNo) == MessageBoxResult.Yes
+                return ChocolateyMessageBox.Show(message, title, MessageBoxButton.YesNo) == MessageBoxResult.Yes
                     ? MessageDialogResult.Affirmative
                     : MessageDialogResult.Negative;
             }

--- a/Source/ChocolateyGui.Common.Windows/Utilities/ChocolateyMessageBox.cs
+++ b/Source/ChocolateyGui.Common.Windows/Utilities/ChocolateyMessageBox.cs
@@ -1,0 +1,97 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="ChocolateyMessageBox.cs">
+//   Copyright 2017 - Present Chocolatey Software, LLC
+//   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ChocolateyGui.Common.Windows.Utilities
+{
+    using System.Windows;
+
+    public static class ChocolateyMessageBox
+    {
+        public static MessageBoxResult Show(string messageBoxText)
+        {
+            return Show(messageBoxText, string.Empty);
+        }
+
+        public static MessageBoxResult Show(string messageBoxText, string caption)
+        {
+            return Show(messageBoxText, caption, MessageBoxButton.OK);
+        }
+
+        public static MessageBoxResult Show(string messageBoxText, string caption, MessageBoxButton button)
+        {
+            return Show(messageBoxText, caption, button, MessageBoxImage.None);
+        }
+
+        public static MessageBoxResult Show(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+        {
+            return Show(messageBoxText, caption, button, icon, MessageBoxResult.OK);
+        }
+
+        public static MessageBoxResult Show(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, MessageBoxResult defaultResult)
+        {
+            return Show(messageBoxText, caption, button, icon, defaultResult, MessageBoxOptions.None);
+        }
+
+        public static MessageBoxResult Show(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, MessageBoxResult defaultResult, MessageBoxOptions options)
+        {
+            var dummyWindow = DummyWindow();
+            dummyWindow.Show();
+            var result = MessageBox.Show(messageBoxText, caption, button, icon, defaultResult, options);
+            dummyWindow.Show();
+            return result;
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText)
+        {
+            return Show(owner, messageBoxText, string.Empty);
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption)
+        {
+            return Show(owner, messageBoxText, caption, MessageBoxButton.OK);
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption, MessageBoxButton button)
+        {
+            return Show(owner, messageBoxText, caption, button, MessageBoxImage.None);
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+        {
+            return Show(owner, messageBoxText, caption, button, icon, MessageBoxResult.OK);
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, MessageBoxResult defaultResult)
+        {
+            return Show(owner, messageBoxText, caption, button, icon, defaultResult, MessageBoxOptions.None);
+        }
+
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, MessageBoxResult defaultResult, MessageBoxOptions options)
+        {
+            var dummyWindow = DummyWindow();
+            dummyWindow.Show();
+            var result = MessageBox.Show(owner, messageBoxText, caption, button, icon, defaultResult, options);
+            dummyWindow.Show();
+            return result;
+        }
+
+        private static Window DummyWindow()
+        {
+            return new Window
+            {
+                AllowsTransparency = true,
+                Background = System.Windows.Media.Brushes.Transparent,
+                WindowStyle = WindowStyle.None,
+                Top = 0,
+                Left = 0,
+                Width = 1,
+                Height = 1,
+                ShowInTaskbar = false
+            };
+        }
+    }
+}

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -24,6 +24,7 @@ using ChocolateyGui.Common.Services;
 using ChocolateyGui.Common.ViewModels;
 using ChocolateyGui.Common.ViewModels.Items;
 using ChocolateyGui.Common.Windows.Services;
+using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.Utilities.Extensions;
 using NuGet;
 using Serilog;
@@ -402,7 +403,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             catch (InvalidOperationException ex)
             {
                 Logger.Error(ex, "Failed to initialize remote source view model.");
-                MessageBox.Show(
+                ChocolateyMessageBox.Show(
                     string.Format(
                         CultureInfo.InvariantCulture,
                         Resources.RemoteSourceViewModel_UnableToConnectToFeed,

--- a/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml.cs
@@ -18,6 +18,7 @@ using ChocolateyGui.Common.Providers;
 using ChocolateyGui.Common.Services;
 using ChocolateyGui.Common.Windows.Controls.Dialogs;
 using ChocolateyGui.Common.Windows.Services;
+using ChocolateyGui.Common.Windows.Utilities;
 using MahApps.Metro.Controls.Dialogs;
 using ChocolateyDialog = ChocolateyGui.Common.Windows.Controls.Dialogs.ChocolateyDialog;
 
@@ -74,7 +75,7 @@ namespace ChocolateyGui.Common.Windows.Views
             if (operatingSystemVersion.Version.Major == 10 &&
                 !_chocolateyConfigurationProvider.IsChocolateyExecutableBeingUsed)
             {
-                MessageBox.Show(
+                ChocolateyMessageBox.Show(
                     "Usage of the PowerShell Version of Chocolatey (i.e. <= 0.9.8.33) has been detected.  Chocolatey GUI does not support using this version of Chocolatey on Windows 10.  Please update Chocolatey to the new C# Version (i.e. > 0.9.9.0) and restart Chocolatey GUI.  This application will now close.",
                     "Incompatible Operating System Version",
                     MessageBoxButton.OK,

--- a/Source/ChocolateyGui/App.xaml.cs
+++ b/Source/ChocolateyGui/App.xaml.cs
@@ -15,6 +15,7 @@ using ChocolateyGui.Common.Services;
 using ChocolateyGui.Common.Startup;
 using ChocolateyGui.Common.Windows;
 using ChocolateyGui.Common.Windows.Theming;
+using ChocolateyGui.Common.Windows.Utilities;
 
 namespace ChocolateyGui
 {
@@ -80,7 +81,7 @@ namespace ChocolateyGui
                 catch (Exception ex)
                 {
                     var errorMessage = string.Format("Unable to load Chocolatey GUI assembly. {0}", ex.Message);
-                    MessageBox.Show(errorMessage);
+                    ChocolateyMessageBox.Show(errorMessage);
                     throw new ApplicationException(errorMessage);
                 }
 


### PR DESCRIPTION
There appears to be a "feature" in WPF that prevents MessageBoxes from
displaying when there are no active windows. Many of our MessageBoxes
are to report errors, and many of them occur during startup. This
results in them not displaying as we haven't created any windows. This
works around that by creating a hidden window and closing it after the
MessageBox has been displayed.


## Description Of Changes

Wrap message boxes with calls to display a hidden window.

## Motivation and Context

There is apparently a "feature" of WPF that prevents message boxes from displaying unless there's a window being displayed.

## Testing

Caveat: I have not verified that all 7 message boxes are displayed, merely the one that I was able to reliably reproduce. I also did not verify the overloads that don't have any references (yet). I merely added them so we have them if needed in the future.

1. Purposed broke the user.config file by putting some bad xml elements in it.
2. Confirmed that Chocolatey GUI displays the message box without immediately dismissing it.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #904 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
