### PR TITLE
(#885) Remove package parameters from nuspec file

### DIFF
--- a/nuspec/chocolatey/ChocolateyGUI.nuspec
+++ b/nuspec/chocolatey/ChocolateyGUI.nuspec
@@ -18,34 +18,7 @@ Chocolatey GUI is a delicious GUI on top of the Chocolatey command line tool.
 
 ## Package Parameters
 
-- `/Global` - Should the configuration change be applied globally, or for the current user.
-- `/ShowConsoleOutput` - Enables/disables whether or not Chocolatey GUI shows output from the commands being executed when a job is running.
-- `/DefaultToTileViewForLocalSource` - Enables/disables whether or not Chocolatey GUI defaults to tile instead of list view for the local source view.
-- `/DefaultToTileViewForRemoteSource` - Enables/disables whether or not Chocolatey GUI defaults to tile instead of list view for all remote source views.
-- `/UseDelayedSearch` - Enables/disables whether or not Chocolatey GUI uses a live search, which returns results after a short delay without clicking the search button.
-- `/PreventPreload` - Prevents preloading results with a blank search when opening the remote source view.
-- `/PreventAutomatedOutdatedPackagesCheck` - Prevents automated check for outdated packages on startup.
-- `/ExcludeInstalledPackages` - Enables/disables whether or not Chocolatey GUI shows packages that are already installed when viewing sources.
-- `/ShowAggregatedSourceView` - Enables/disables whether or not Chocolatey GUI shows an additional source combining all sources into one location.
-- `/ShowAdditionalPackageInformation` - Show additional package information on Local and Remote views.
-- `/AllowNonAdminAccessToSettings` - Controls whether or not a non-administrator user can access the Settings Screen.  NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-- `/UseKeyboardBindings` - Allows keyboard bindings to be used to interact with different areas of the Chocolatey GUI User Interface.
-- `/HidePackageDownloadCount` - Allows keyboard bindings to be used to interact with different areas of the Chocolatey GUI User Interface.
-- `/PreventAllPackageIconDownloads` - Enables/disables whether Chocolatey GUI will attempt to download the icons for packages. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-- `/HideAllRemoteChocolateySources` - Enable/disables whether or not all remote sources are hidden - essentially enabling a read-only view of installed packages. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-- `/DefaultToDarkMode` - Enables/disables whether or not Chocolatey GUI defaults to using dark mode for the Chocolatey GUI User Interface.
-- `/OutdatedPackagesCacheDurationInMinutes` - The length of time, in minutes, which Chocolatey GUI will wait before invalidating the cached result of outdated packages for the machine.
-- `/DefaultSourceName` - The name of the source which should be shown by default when opening application. NOTE: This configuration setting will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-- `/HideThisPCSource` - Enable/disables whether or not This PC source is hidden. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-- `/PreventUsageOfUpdateAllButton` - Enables/disables whether the Update All button is visible. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.
-
-As an example, the following installation command could be used to enable `ShowConsoleOutput` to ensure `UseDelayedSearch` is disabled, and set the output cache to 120 minutes:
-
-`choco install chocolateygui --params="'/ShowConsoleOutput=$true /UseDelayedSearch=$false /OutdatedPackagesCacheDurationInMinutes=120'"`
-
-If you wanted to set these options globally so that all users on the machine got these values, run the following:
-
-`choco install chocolateygui --params="'/ShowConsoleOutput=$true /UseDelayedSearch=$false /OutdatedPackagesCacheDurationInMinutes=120 /Global'"`
+See [Chocolatey GUI documentation page](https://docs.chocolatey.org/en-us/chocolatey-gui/setup/installation#package-parameters) for available package parameters.
     </description>
     <summary>A GUI for Chocolatey</summary>
   <releaseNotes>


### PR DESCRIPTION
## Description Of Changes

This commit updates the Chocolatey Package to instead of embedding
the package parameter for the package to link to the documentation
page for Chocolatey GUI on https://docs.chocolatey.org instead.

## Motivation and Context

This was needed as we are starting to hit the character limitation
specified for the description in packages (4 000 characters).

## Testing

This is only a documentation change, no running code have been touched as such testing have not been done.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Documentation change

## Related Issue

Fixes #885

## Change Checklist

* [x] Requires a change to the documentation (kind of, see https://github.com/chocolatey/docs/issues/320)
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed (Not checked as code have not been touched).
* [ ] PowerShell v2 compatibility checked.

