### PR TITLE
(#770) Provide ability to see persisted arguments for installed package

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
@@ -61,7 +61,7 @@ namespace ChocolateyGui.Common.Windows.Services
 
             if (string.IsNullOrEmpty(arguments))
             {
-                _dialogService.ShowMessageAsync(
+                Logger.Debug(
                     string.Empty,
                     L(nameof(Resources.PackageView_UnableToFindArgumentsFile), version, id));
                 yield break;

--- a/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
@@ -73,6 +73,8 @@ namespace ChocolateyGui.Common.Windows.Services
                 ? arguments
                 : _encryptionUtility.decrypt_string(arguments);
 
+            // Lets do a global check first to see if there are any sensitive arguments
+            // before we filter out the values used later.
             var sensitiveArgs = ArgumentsUtility.arguments_contain_sensitive_information(packageArgumentsUnencrypted);
 
             var packageArgumentsSplit =
@@ -80,12 +82,19 @@ namespace ChocolateyGui.Common.Windows.Services
 
             foreach (var packageArgument in packageArgumentsSplit.or_empty_list_if_null())
             {
+                var isSensitiveArgument = sensitiveArgs && ArgumentsUtility.arguments_contain_sensitive_information(packageArgument);
+
                 var packageArgumentSplit =
                     packageArgument.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries);
+
                 var optionName = packageArgumentSplit[0].to_string();
                 var optionValue = string.Empty;
 
-                if (packageArgumentSplit.Length == 2)
+                if (packageArgumentSplit.Length == 2 && isSensitiveArgument)
+                {
+                    optionValue = L(nameof(Resources.PackageArgumentService_RedactedArgument));
+                }
+                else if (packageArgumentSplit.Length == 2)
                 {
                     optionValue = packageArgumentSplit[1].to_string().remove_surrounding_quotes();
                     if (optionValue.StartsWith("'"))

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -431,9 +431,18 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
         {
             var decryptedArguments = _packageArgumentsService.DecryptPackageArgumentsFile(Id, Version.ToString()).ToList();
 
-            await _dialogService.ShowMessageAsync(
-                L(nameof(Resources.PackageViewModel_ArgumentsForPackageFormat), Title),
-                string.Join(Environment.NewLine, decryptedArguments));
+            if (decryptedArguments.Count == 0)
+            {
+                await _dialogService.ShowMessageAsync(
+                    L(nameof(Resources.PackageViewModel_ArgumentsForPackageFormat), Title),
+                    L(nameof(Resources.PackageViewModel_NoArgumentsAvailableForPackage)));
+            }
+            else
+            {
+                await _dialogService.ShowMessageAsync(
+                    L(nameof(Resources.PackageViewModel_ArgumentsForPackageFormat), Title),
+                    string.Join(Environment.NewLine, decryptedArguments));
+            }
         }
 
         public async Task Install()

--- a/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
@@ -62,7 +62,8 @@
                     Background="{DynamicResource MahApps.Brushes.Accent4}">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,20,10">
                         <Button Padding="10" Margin="5 0"
-                            Command="{commands:DataContextCommandAdapter ShowArguments}">
+                            Command="{commands:DataContextCommandAdapter ShowArguments}"
+                            Visibility="{Binding IsInstalled, Converter={StaticResource BooleanToVisibility}, ConverterParameter=False}">
                             <StackPanel Orientation="Horizontal">
                                 <iconPacks:PackIconEntypo Kind="Info" Margin="0 0 5 0 " VerticalAlignment="Center" />
                                 <TextBlock Text="{lang:Localize PackageView_ButtonPackageArguments}" FontSize="16"/>

--- a/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
+++ b/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
@@ -27,7 +27,7 @@ namespace ChocolateyGui.Common.Models
         [Config]
         public string NumberOfPackageVersionsForSelection { get; set; }
 
-        [LocalizedDescription(nameof(Resources.SettingsView_Language))]
+        [LocalizedDescription(nameof(Resources.SettingsView_LanguageDescription))]
         [Config]
         public string UseLanguage { get; set; }
 

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -2899,6 +2899,15 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The preferred language for Chocolatey GUI. Defaults to Windows System Locale..
+        /// </summary>
+        public static string SettingsView_LanguageDescription {
+            get {
+                return ResourceManager.GetString("SettingsView_LanguageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Default number of package versions shown when performing an advanced installation.  Default is 20. 0 should be used to show all available package versions..
         /// </summary>
         public static string SettingsView_NumberOfPackageVersionsForSelectionDescription {

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -1929,6 +1929,15 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [REDACTED ARGUMENT].
+        /// </summary>
+        public static string PackageArgumentService_RedactedArgument {
+            get {
+                return ResourceManager.GetString("PackageArgumentService_RedactedArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installed.
         /// </summary>
         public static string PackagesView_Installed {
@@ -2628,7 +2637,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Got to the Previous Page.
+        ///   Looks up a localized string similar to Go to the Previous Page.
         /// </summary>
         public static string RemoteSourceView_TooltipGoBackAPage {
             get {

--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -2289,6 +2289,15 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There are no Persisted Arguments available for this package!.
+        /// </summary>
+        public static string PackageViewModel_NoArgumentsAvailableForPackage {
+            get {
+                return ResourceManager.GetString("PackageViewModel_NoArgumentsAvailableForPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pinning package.
         /// </summary>
         public static string PackageViewModel_PinningPackage {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1352,4 +1352,7 @@ Please contact your System Administrator to enable this operation.</value>
   <data name="PackageViewModel_NoArgumentsAvailableForPackage" xml:space="preserve">
     <value>There are no Persisted Arguments available for this package!</value>
   </data>
+  <data name="SettingsView_LanguageDescription" xml:space="preserve">
+    <value>The preferred language for Chocolatey GUI. Defaults to Windows System Locale.</value>
+  </data>
 </root>

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1346,4 +1346,7 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Arguments for the Package {0}</value>
     <comment>{0} = The Title of the package</comment>
   </data>
+  <data name="PackageArgumentService_RedactedArgument" xml:space="preserve">
+    <value>[REDACTED ARGUMENT]</value>
+  </data>
 </root>

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1349,4 +1349,7 @@ Please contact your System Administrator to enable this operation.</value>
   <data name="PackageArgumentService_RedactedArgument" xml:space="preserve">
     <value>[REDACTED ARGUMENT]</value>
   </data>
+  <data name="PackageViewModel_NoArgumentsAvailableForPackage" xml:space="preserve">
+    <value>There are no Persisted Arguments available for this package!</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description Of Changes

This pull request updates the code that was added previously for displaying package arguments with code to hide sensitive arguments, only do a log if the arguments file can not be found, display a message about no arguments could not be found if nothing is returned and to hide the button for viewing package arguments when the package is not installed.

## Motivation and Context

The sensitive arguments are changed to not be displayed, as we do not want to dispay these arguments to the users in the possibility that they are not the same user as the one that installed the package.

Changing to logging of the file not found was to prevent duplicated dialogs to be shown, but still give the information about no arguments being available.

Additionally, there is no reason to be able to view package arguments for packages that are not installed.

## Testing

1. Install a package using package arguments (must be at least non-sensitive arguments used, sensitive arguments are usually not persisted) (install through choco cli)
2. Try viewing the package arguments for the package that was installed.
3. Notice no more duplication of dialogs.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change) (This is a bug fix to a feature introduced on this milestone)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #770

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked (Not relevant).

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
