### PR TITLE
Fix typo in window seen after export command finishes

### DIFF
--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1242,7 +1242,7 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Prevents the ability for user to use the Update All button. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.</value>
   </data>
   <data name="LocalSourceViewModel_ExportComplete" xml:space="preserve">
-    <value>All the currrently installed packages have been exported to {0}</value>
+    <value>All the currently installed packages have been exported to {0}</value>
     <comment>{0} = The path to where the exported packages have been placed</comment>
   </data>
   <data name="SettingsView_Language" xml:space="preserve">


### PR DESCRIPTION
## Description Of Changes

Fixed a simple typo: "currrently" -> "currently". Trivial fix, so no need for the CLA?

## Motivation and Context

N/A

## Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

N/A

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
