### PR TITLE
(build) Adds TeamCity build definition

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Chocolatey GUI Config DSL Script</name>
+  <groupId>Chocolatey</groupId>
+  <artifactId>ChocolateyGUI</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.jetbrains.teamcity</groupId>
+    <artifactId>configs-dsl-kotlin-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jetbrains-all</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>teamcity-server</id>
+      <url>https://teamcityserver/app/dsl-plugins-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>JetBrains</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <sourceDirectory>${basedir}</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>teamcity-configs-maven-plugin</artifactId>
+        <version>${teamcity.dsl.version}</version>
+        <configuration>
+          <format>kotlin</format>
+          <dstDir>target/generated-configs</dstDir>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-script-runtime</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,0 +1,88 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.XmlReport
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nuGetPublish
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+
+version = "2021.2"
+
+project {
+    buildType(ChocolateyGUI)
+}
+
+object ChocolateyGUI : BuildType({
+    id = AbsoluteId("ChocolateyGUI")
+    name = "Build"
+
+    artifactRules = """
+        code_drop/MsBuild.log
+        code_drop/MSBuild.msi.log
+        code_drop/ChocolateyGUI.msi
+        code_drop/TestResults/issues-report.html
+        code_drop/Packages/**/*.nupkg
+    """.trimIndent()
+
+    params {
+        param("env.vcsroot.branch", "%vcsroot.branch%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.ChocolateyGUI_ChocolateyGuiVcsRoot%")
+        param("teamcity.git.fetchAllHeads", "true")
+        password("env.TRANSIFEX_API_TOKEN", "credentialsJSON:c81283e6-cf59-5c9e-9766-6f465018a295", display = ParameterDisplay.HIDDEN, readOnly = true)
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+
+        branchFilter = """
+            +:*
+        """.trimIndent()
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    # Install Chocolatey Requirements
+                    if ((Get-WindowsFeature -Name NET-Framework-Features).InstallState -ne 'Installed') {
+                        Install-WindowsFeature -Name NET-Framework-Features
+                    }
+
+                    choco install visualstudio2019buildtools netfx-4.8-devpack --confirm --no-progress
+                    exit ${'$'}LastExitCode
+                """.trimIndent()
+            }
+        }
+
+        step {
+            name = "Include Signing Keys"
+            type = "PrepareSigningEnvironment"
+        }
+
+        script {
+            name = "Call Cake"
+            scriptContent = "call build.official.bat"
+        }
+    }
+
+    triggers {
+        vcs {
+            branchFilter = ""
+        }
+    }
+
+    features {
+        pullRequests {
+            vcsRootExtId = "${DslContext.settingsRoot}"
+            provider = github {
+                authType = token {
+                    token = "%system.GitHubPAT%"
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Description Of Changes

This commit adds a build definition to be used by the Chocolatey
internal TeamCity server.

This calls the build.official.bat script, as it will have access to the
required files in order to create an official signed version of
Chocolatey GUI.

Setup of this build uses the build of Chocolatey GUI Licensed Extension
as a template, and then modified the necessary portions to make it
specific to Chocolatey GUI.

## Motivation and Context

All Chocolatey builds are going to happen on an internal TeamCity server, to allow for full signing of the generated assemblies.

## Testing

The TeamCity build configuration has been tested on a previous TeamCity server, and brought over in the settings.kts file.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

N/A

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.