### PR TITLE
(#928) Update Chocolatey CLI to latest pre-release

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -67,8 +67,8 @@
     <Reference Include="Caliburn.Micro.Platform.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.11.1.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.11.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=1.0.0.52, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.1.0.0-alpha-20220315-52\lib\chocolatey.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -5,7 +5,7 @@
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net40" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net48" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net48" />
-  <package id="chocolatey.lib" version="0.11.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="1.0.0-alpha-20220315-52" targetFramework="net48" />
   <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
   <package id="Fizzler" version="1.2.0" targetFramework="net48" />
   <package id="HarfBuzzSharp" version="2.6.1.4" targetFramework="net48" />

--- a/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
+++ b/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
@@ -54,8 +54,8 @@
     <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.11.1.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.11.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=1.0.0.52, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.1.0.0-alpha-20220315-52\lib\chocolatey.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>

--- a/Source/ChocolateyGui.Common/packages.config
+++ b/Source/ChocolateyGui.Common/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
   <package id="AutoMapper" version="7.0.1" targetFramework="net48" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
-  <package id="chocolatey.lib" version="0.11.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="1.0.0-alpha-20220315-52" targetFramework="net48" />
   <package id="LiteDB" version="5.0.5" targetFramework="net452" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -113,8 +113,8 @@
     <Reference Include="Caliburn.Micro.Platform.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.11.1.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.11.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=1.0.0.52, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.1.0.0-alpha-20220315-52\lib\chocolatey.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -5,7 +5,7 @@
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net452" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
-  <package id="chocolatey.lib" version="0.11.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="1.0.0-alpha-20220315-52" targetFramework="net48" />
   <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
   <package id="Fizzler" version="1.2.0" targetFramework="net48" />
   <package id="HarfBuzzSharp" version="2.6.1.4" targetFramework="net48" />

--- a/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
+++ b/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
@@ -56,8 +56,8 @@
     <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=0.11.1.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.0.11.1\lib\chocolatey.dll</HintPath>
+    <Reference Include="chocolatey, Version=1.0.0.52, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.1.0.0-alpha-20220315-52\lib\chocolatey.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>

--- a/Source/ChocolateyGuiCli/packages.config
+++ b/Source/ChocolateyGuiCli/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
-  <package id="chocolatey.lib" version="0.11.1" targetFramework="net452" />
+  <package id="chocolatey.lib" version="1.0.0-alpha-20220315-52" targetFramework="net48" />
   <package id="LiteDB" version="5.0.5" targetFramework="net452" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Serilog" version="2.5.0" targetFramework="net48" />

--- a/nuspec/chocolatey/ChocolateyGUI.nuspec
+++ b/nuspec/chocolatey/ChocolateyGUI.nuspec
@@ -26,7 +26,7 @@ All release notes for Chocolatey GUI can be found on the docs site - https://doc
   </releaseNotes>
     <tags>chocolateygui chocolatey admin foss</tags>
     <dependencies>
-      <dependency id="Chocolatey" version="0.11.1" />
+      <dependency id="Chocolatey" version="[1.0.0-alpha, 2.0.0)" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="dotnetfx" version="4.8.0.20190930" />
     </dependencies>


### PR DESCRIPTION
## Description Of Changes

This commit updates the the dependency for Chocolatey CLI
to the latest pre-release we have available internally.
This will prevent temporarily users from building the project
until a new release is made.

Additionally a pre-release version range is added to the nuspec
file to allow us to test upcoming functionality in the way we
want.

## Motivation and Context

To allow us to test the functionality and installation we intend for upcoming releases.

## Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Related #928  
https://app.clickup.com/t/20540031/ENGTASKS-1149

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
