### PR TITLE
(maint) Add sources explicitly during cake build

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -92,6 +92,17 @@ Func<FilePathCollection> getMsisToSign = () =>
     return msisToSign;
 };
 
+var nugetSources = new List<string>
+{
+    "https://www.nuget.org/api/v2/",
+    "https://api.nuget.org/v3/index.json"
+};
+
+if (HasEnvironmentVariable("NUGETDEV_SOURCE"))
+{
+    nugetSources.Add(EnvironmentVariable("NUGETDEV_SOURCE"));
+}
+
 BuildParameters.SetParameters(context: Context,
                             buildSystem: BuildSystem,
                             sourceDirectoryPath: "./Source",
@@ -110,6 +121,7 @@ BuildParameters.SetParameters(context: Context,
                             getFilesToSign: getFilesToSign,
                             getMsisToSign: getMsisToSign,
                             shouldBuildMsi: true,
+                            nuGetSources: nugetSources,
                             strongNameDependentAssembliesInputPath: string.Format("{0}{1}", ((FilePath)("./Source")).FullPath, "\\packages\\Splat*"));
 
 ToolSettings.SetToolSettings(context: Context,


### PR DESCRIPTION
## Description Of Changes

This commit updates the cake build script to add
the sources we need to use explicitly, with the
ability to add a nuget source from an environment
variable when it is present.

## Motivation and Context

This is needed due to a temporary change to use
versions of Chocolatey CLI that are only available
on our internal feed currently.

## Testing

1. Tested by running build.ps1

## Change Types Made

* [x] Bug fix (non-breaking change) (until implementation is done upstream)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

https://app.clickup.com/t/20540031/ENGTASKS-1149

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
