### PR TITLE
(#956) Add initial set of Pester tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,12 @@ The only reasons a pull request should be closed and resubmitted are as follows:
   * When the pull request is targeting the wrong branch (this doesn't happen as often).
   * When there are updates made to the original by someone other than the original contributor. Then the old branch is closed with a note on the newer branch this supersedes #github_number.
 
+### Testing
+
+There are some barebones Pester tests used to test the very basic functionalities of `chocolateyguicli`. These require Pester version 5.3.1 or newer. They can be launched by running `Invoke-Pester` within the `Tests` directory of the repository.
+
+It is **not currently** expected that these Pester tests are run before submitting a PR. Their purpose at the moment is to establish a base to build upon.
+
 ### Debugging with Chocolatey library information
 
 In order to debug Chocolatey GUI, you need Chocolatey.Lib referenced in the project to match the Chocolatey version installed locally on your system. The easiest way to do this is to run `./Update-DebugConfiguration.ps1` from the root of the repository.

--- a/Tests/chocolateyguicli.Tests.ps1
+++ b/Tests/chocolateyguicli.Tests.ps1
@@ -1,0 +1,49 @@
+Import-Module helpers/gui-helpers
+
+Describe "chocolateyguicli" -Tag ChocolateyGuiCli {
+    BeforeDiscovery {
+        # Perhaps a better way is to pull these from the LiteDB similar to how we do features from the xml in CLI, but this will do for an initial setup.
+        $Features = (Invoke-GuiCli feature list -r).Lines | ConvertFrom-Csv -Delimiter '|' -Header Name, state, description | Select-Object Name, @{Name = 'enabled'; Expression = { $_.state -eq 'Enabled' } }
+        $Features | Out-string | write-host
+    }
+
+    Context "Basic CLI functionality" {
+        BeforeAll {
+            $Output = Invoke-GuiCli
+        }
+
+        It 'Should exit Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Should output appropriate message' {
+            $Output.Lines | Should -Contain "Please run chocolateyguicli with 'chocolateyguicli -?' or 'chocolateyguicli <command> -?' for specific help on each command"
+        }
+    }
+
+    Context "Lists available features" {
+        BeforeAll {
+            $Output = Invoke-GuiCli feature list
+        }
+
+        It "Contains reference of the option (<_.Name>)" -ForEach $Features {
+            $Output.String | Should -Match $Name
+        }
+    }
+    
+    Context "Toggles the feature (<_.Name>) successfully" -ForEach $Features {
+        BeforeAll {
+            $Outputs = if ($Enabled) {
+                Invoke-GuiCli feature disable --name $_.Name
+                Invoke-GuiCli feature enable --name $_.Name
+            } else {
+                Invoke-GuiCli feature enable --name $_.Name
+                Invoke-GuiCli feature disable --name $_.Name
+            }
+        }
+
+        It "Should exit success" {
+            $Outputs.ExitCode | Should -Not -Contain 1
+        }
+    }
+}

--- a/Tests/chocolateyguicli.Tests.ps1
+++ b/Tests/chocolateyguicli.Tests.ps1
@@ -1,10 +1,9 @@
-Import-Module helpers/gui-helpers
+Import-Module ./helpers/gui-helpers.psm1
 
 Describe "chocolateyguicli" -Tag ChocolateyGuiCli {
     BeforeDiscovery {
         # Perhaps a better way is to pull these from the LiteDB similar to how we do features from the xml in CLI, but this will do for an initial setup.
-        $Features = (Invoke-GuiCli feature list -r).Lines | ConvertFrom-Csv -Delimiter '|' -Header Name, state, description | Select-Object Name, @{Name = 'enabled'; Expression = { $_.state -eq 'Enabled' } }
-        $Features | Out-string | write-host
+        $Features = Get-GuiFeature
     }
 
     Context "Basic CLI functionality" {

--- a/Tests/helpers/gui-helpers.psm1
+++ b/Tests/helpers/gui-helpers.psm1
@@ -1,0 +1,1 @@
+Get-ChildItem -Path $PSScriptRoot\gui -Filter *.ps1 -Recurse | ForEach-Object { . $_.FullName }

--- a/Tests/helpers/gui/Get-GuiFeature.ps1
+++ b/Tests/helpers/gui/Get-GuiFeature.ps1
@@ -1,0 +1,17 @@
+function Get-GuiFeature {
+    <#
+        .Synopsis
+            Helper function to call chocolateyguicli and return the feature information as a PSCustomObject.
+    #>
+    [CmdletBinding()]
+    param(
+        [string[]]$Feature = '*'
+    )
+
+    $featureList = (Invoke-GuiCli feature list -r).Lines |
+        ConvertFrom-Csv -Delimiter '|' -Header Name, State, Description |
+        Select-Object Name, @{Name = 'enabled'; Expression = { $_.State -eq 'Enabled' } }, Description
+    foreach ($ftr in $Feature) {
+        $featureList | Where-Object Name -Like $ftr
+    }
+}

--- a/Tests/helpers/gui/Invoke-GuiCli.ps1
+++ b/Tests/helpers/gui/Invoke-GuiCli.ps1
@@ -1,0 +1,23 @@
+function Invoke-GuiCli {
+    <#
+        .Synopsis
+            Helper function to call chocolatey with any number of specified arguments,
+            and return a hashtable with the output as well as the exit code.
+    #>
+    [CmdletBinding()]
+    param(
+        # The arguments to use when calling the Choco executable
+        [Parameter(Position = 1, ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    $output = & chocolateyguicli.exe @arguments
+    [PSCustomObject]@{
+        # We trim all the lines, so we do not take into account
+        # trimming the lines when asserting, and that extra whitespace
+        # is not considered in our assertions.
+        Lines    = if ($output) { $output.Trim() } else { @() }
+        String   = $output -join "`r`n"
+        ExitCode = $LastExitCode
+    }
+}

--- a/Tests/helpers/gui/Invoke-GuiCli.ps1
+++ b/Tests/helpers/gui/Invoke-GuiCli.ps1
@@ -1,12 +1,12 @@
 function Invoke-GuiCli {
     <#
         .Synopsis
-            Helper function to call chocolatey with any number of specified arguments,
+            Helper function to call chocolateyguicli with any number of specified arguments,
             and return a hashtable with the output as well as the exit code.
     #>
     [CmdletBinding()]
     param(
-        # The arguments to use when calling the Choco executable
+        # The arguments to use when calling the chocolateyguicli executable
         [Parameter(Position = 1, ValueFromRemainingArguments)]
         [string[]]$Arguments
     )


### PR DESCRIPTION
## Description Of Changes

Add some initial Pester tests.

## Motivation and Context

There is some very basic tests of `chocolateyguicli` that we do as part of manual testing before a release. This puts those into Pester tests so we don't have to manually do them.

## Testing

On a system with Chocolatey GUI installed:

1. Run: `Install-Module Pester -MinimumVersion 5.3.1 -SkipPublisherCheck -Force -Scope CurrentUser`
2. From the `Tests` directory run `Invoke-Pester`
3. Confirmed all tests returned successfully.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #956 

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
