### PR TITLE
(#902) Add debug info to Contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ The only reasons a pull request should be closed and resubmitted are as follows:
 
 In order to debug Chocolatey GUI, you need Chocolatey.Lib referenced in the project to match the Chocolatey version installed locally on your system. The easiest way to do this is to run `./Update-DebugConfiguration.ps1` from the root of the repository.
 
-> :warning: **Note:**
+> :warning: **NOTE**
 >
 > You will need to have `nuget.commandline` installed for this script to work.
 >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,12 +108,12 @@ The only reasons a pull request should be closed and resubmitted are as follows:
 
 ### Debugging with Chocolatey library information
 
-In order to debug Chocolatey GUI, you need Chocolatey.Lib referenced in the project to match the Chocolatey version installed locally on your system. The easiest way to do this is to run `./Update-DebugConfiguration.ps1` from the root of the repository. 
+In order to debug Chocolatey GUI, you need Chocolatey.Lib referenced in the project to match the Chocolatey version installed locally on your system. The easiest way to do this is to run `./Update-DebugConfiguration.ps1` from the root of the repository.
 
 > :warning: **Note:**
-> 
+>
 > You will need to have `nuget.commandline` installed for this script to work.
-> 
+>
 > You will also want to **not** commit the changes this script makes to the `.csproj` and `packages.config` files. As such, if you're making changes that would modify any of these files, it is recommended to make those changes, commit, then run the `./Update-DebugConfiguration.ps1` script.
 
 ## Other General Information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,16 @@ The only reasons a pull request should be closed and resubmitted are as follows:
   * When the pull request is targeting the wrong branch (this doesn't happen as often).
   * When there are updates made to the original by someone other than the original contributor. Then the old branch is closed with a note on the newer branch this supersedes #github_number.
 
+### Debugging with Chocolatey library information
+
+In order to debug Chocolatey GUI, you need Chocolatey.Lib referenced in the project to match the Chocolatey version installed locally on your system. The easiest way to do this is to run `./Update-DebugConfiguration.ps1` from the root of the repository. 
+
+> :warning: **Note:**
+> 
+> You will need to have `nuget.commandline` installed for this script to work.
+> 
+> You will also want to **not** commit the changes this script makes to the `.csproj` and `packages.config` files. As such, if you're making changes that would modify any of these files, it is recommended to make those changes, commit, then run the `./Update-DebugConfiguration.ps1` script.
+
 ## Other General Information
 
 If you reformat code or hit core functionality without an approval from a person on the Chocolatey Team, it's likely that no matter how awesome it looks afterwards, it will probably not get accepted. Reformatting code makes it harder for us to evaluate exactly what was changed.

--- a/Update-DebugConfiguration.ps1
+++ b/Update-DebugConfiguration.ps1
@@ -3,7 +3,7 @@ $NugetPackage = $ChocolateyPackages | Where-Object Package -EQ nuget.commandline
 $ChocolateyVersion = $ChocolateyPackages | Where-Object Package -EQ 'chocolatey'
 
 If ($null -eq $NugetPackage) {
-    throw "You must have nuget.commandline installed in order to automatically update Chocolatey.lib. Alternatively you can update Chocolatey.lib in Visual Studio to Version '$ChocolateyVersion'"
+    throw "You must have nuget.commandline installed in order to automatically update Chocolatey.lib. Alternatively you can update Chocolatey.lib in Visual Studio to Version '$($ChocolateyVersion.Version)'"
 }
 
 nuget restore $PSScriptRoot/Source/ChocolateyGui.sln

--- a/Update-DebugConfiguration.ps1
+++ b/Update-DebugConfiguration.ps1
@@ -1,0 +1,10 @@
+$ChocolateyPackages = choco list -lo -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version
+$NugetPackage = $ChocolateyPackages | Where-Object Package -EQ nuget.commandline
+$ChocolateyVersion = $ChocolateyPackages | Where-Object Package -EQ 'chocolatey'
+
+If ($null -eq $NugetPackage) {
+    throw "You must have nuget.commandline installed in order to automatically update Chocolatey.lib. Alternatively you can update Chocolatey.lib in Visual Studio to Version '$ChocolateyVersion'"
+}
+
+nuget restore $PSScriptRoot/Source/ChocolateyGui.sln
+nuget update $PSScriptRoot/Source/ChocolateyGui.sln -Id Chocolatey.lib -Version $ChocolateyVersion.Version


### PR DESCRIPTION
## Description Of Changes

Add debugging information to contributing document and provide a script to help with the process.

## Motivation and Context

Because Chocolatey GUI depends on the system installed Chocolatey, the Chocolatey.Lib package needs to be the same version that is installed. This isn't currently called out in the contributing documentation, nor do we provide an easy way to update.

## Testing

I have used the provided script several times to update the Chocolatey.Lib version targeted while working on the 1.1.0 release.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #902

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.