### PR TITLE
(build) Allow building with Visual Studio 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you would like to contribute code or help squash a bug or two, that's awesome
 
 ### Building
 
-* It is assumed that a version of Visual Studio 2019 is already installed on the machine being used to complete the build.
+* It is assumed that a version of Visual Studio 2019 or newer is already installed on the machine being used to complete the build.
 * `choco install wixtoolset -y`
 * **OPTIONAL:** Set `FXCOPDIR` environment variable, which can be set using [vswhere](https://chocolatey.org/packages/vswhere) and the following command:
    ```ps1

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.19.0
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.20.1
 
 ///////////////////////////////////////////////////////////////////////////////
 // MODULES
@@ -112,8 +112,7 @@ BuildParameters.SetParameters(context: Context,
                             shouldBuildMsi: true,
                             strongNameDependentAssembliesInputPath: string.Format("{0}{1}", ((FilePath)("./Source")).FullPath, "\\packages\\Splat*"));
 
-ToolSettings.SetToolSettings(context: Context,
-                            buildMSBuildToolVersion: MSBuildToolVersion.VS2019);
+ToolSettings.SetToolSettings(context: Context);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
## Description Of Changes

Update to allow building with Visual Studio 2022 alone.

## Motivation and Context

We no longer need to hard code the required Visual Studio version as the chocolatey cake recipe has been updated.

## Testing

On a system with only Visual Studio 2022 installed ran the build script. Confirmed Chocolatey GUI built as expected.

### Operating Systems Testing

This is not a code change, but the OS used to build was Windows 10 22H2.

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build change

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
