### PR TITLE
(#974) Preliminary update chocolatey.lib

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 1.0.0
+next-version: 2.0.0

--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -67,10 +67,8 @@
     <Reference Include="Caliburn.Micro.Platform.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=1.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.1.0.0\lib\chocolatey.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="chocolatey, Version=2.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.2.0.0-alpha-20230124\lib\net48\chocolatey.dll</HintPath>
     </Reference>
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.4.4.0\lib\net462\ControlzEx.dll</HintPath>

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -23,6 +23,7 @@ using ChocolateyGui.Common.Services;
 using ChocolateyGui.Common.Utilities;
 using Microsoft.VisualStudio.Threading;
 using NuGet;
+using NuGet.Versioning;
 using ChocolateySource = ChocolateyGui.Common.Models.ChocolateySource;
 using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
@@ -323,7 +324,7 @@ namespace ChocolateyGui.Common.Windows.Services
             return GetMappedPackage(_choco, new PackageResult(nugetPackage, null, chocoConfig.Sources), _mapper);
         }
 
-        public async Task<List<SemanticVersion>> GetAvailableVersionsForPackageIdAsync(string id, int page, int pageSize, bool includePreRelease)
+        public async Task<List<NuGetVersion>> GetAvailableVersionsForPackageIdAsync(string id, int page, int pageSize, bool includePreRelease)
         {
             _choco.Set(
                 config =>
@@ -343,7 +344,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 });
             var chocoConfig = _choco.GetConfiguration();
             var packages = await _choco.ListAsync<PackageResult>();
-            return packages.Select(p => new SemanticVersion(p.Version)).OrderByDescending(p => p.Version).ToList();
+            return packages.Select(p => NuGetVersion.Parse(p.Version)).OrderByDescending(p => p.Version).ToList();
         }
 
         public async Task<PackageOperationResult> UninstallPackage(string id, string version, bool force = false)
@@ -628,7 +629,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 mappedPackage.IsInstalled = !string.IsNullOrWhiteSpace(package.InstallLocation) || forceInstalled;
                 mappedPackage.IsSideBySide = packageInfo.IsSideBySide;
 
-                mappedPackage.IsPrerelease = !string.IsNullOrWhiteSpace(mappedPackage.Version.SpecialVersion);
+                mappedPackage.IsPrerelease = mappedPackage.Version.IsPrerelease;
 
                 // Add a sanity check here for pre-release packages
                 // By default, pre-release packages are marked as IsLatestVersion = false, however, IsLatestVersion is

--- a/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
+++ b/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
@@ -29,7 +29,7 @@ using ChocolateyGui.Common.Windows.Services;
 using ChocolateyGui.Common.Windows.ViewModels;
 using ChocolateyGui.Common.Windows.Views;
 using LiteDB;
-using NuGet;
+using NuGet.Protocol.Core.Types;
 using ChocolateySource = chocolatey.infrastructure.app.configuration.ChocolateySource;
 using Environment = System.Environment;
 using PackageViewModel = ChocolateyGui.Common.Windows.ViewModels.Items.PackageViewModel;
@@ -94,10 +94,11 @@ namespace ChocolateyGui.Common.Windows.Startup
                 config.CreateMap<IPackageViewModel, IPackageViewModel>()
                     .ForMember(vm => vm.IsInstalled, options => options.Ignore());
 
-                config.CreateMap<DataServicePackage, Package>()
+                config.CreateMap<IPackageSearchMetadata, Package>()
+                    .ForMember(dest => dest.Version, opt => opt.MapFrom(src => src.Identity.Version))
+                    .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Identity.Id))
                     .ForMember(dest => dest.Authors, opt => opt.MapFrom(src => src.Authors.Split(',')))
                     .ForMember(dest => dest.Owners, opt => opt.MapFrom(src => src.Owners.Split(',')));
-                config.CreateMap<IPackage, Package>();
 
                 config.CreateMap<ConfigFileFeatureSetting, ChocolateyFeature>();
                 config.CreateMap<ConfigFileConfigSetting, ChocolateySetting>();

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
@@ -18,7 +18,7 @@ using ChocolateyGui.Common.Services;
 using ChocolateyGui.Common.Windows.Commands;
 using ChocolateyGui.Common.Windows.Controls.Dialogs;
 using ChocolateyGui.Common.Windows.Utilities;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Windows.ViewModels
 {
@@ -60,7 +60,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         public AdvancedInstallViewModel(
             IChocolateyService chocolateyService,
             IPersistenceService persistenceService,
-            SemanticVersion packageVersion)
+            NuGetVersion packageVersion)
         {
             _chocolateyService = chocolateyService;
             _persistenceService = persistenceService;
@@ -75,7 +75,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             AvailableChecksumTypes = new List<string> { "md5", "sha1", "sha256", "sha512" };
             InstallCommand = new RelayCommand(
                 o => { Close?.Invoke(this); },
-                o => string.IsNullOrEmpty(SelectedVersion) || SelectedVersion == Resources.AdvancedChocolateyDialog_LatestVersion || SemanticVersion.TryParse(SelectedVersion, out _));
+                o => string.IsNullOrEmpty(SelectedVersion) || SelectedVersion == Resources.AdvancedChocolateyDialog_LatestVersion || NuGetVersion.TryParse(SelectedVersion, out _));
             CancelCommand = new RelayCommand(
                 o =>
                 {
@@ -437,11 +437,11 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         private void OnSelectedVersionChanged(string stringVersion)
         {
-            SemanticVersion version;
+            NuGetVersion version;
 
-            if (SemanticVersion.TryParse(stringVersion, out version))
+            if (NuGetVersion.TryParse(stringVersion, out version))
             {
-                PreRelease = !string.IsNullOrEmpty(version.SpecialVersion);
+                PreRelease = version.IsPrerelease;
             }
         }
 

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -20,7 +20,7 @@ using ChocolateyGui.Common.ViewModels.Items;
 using ChocolateyGui.Common.Windows.Services;
 using ChocolateyGui.Common.Windows.Views;
 using MahApps.Metro.Controls.Dialogs;
-using NuGet;
+using NuGet.Versioning;
 using Action = System.Action;
 using MemoryCache = System.Runtime.Caching.MemoryCache;
 
@@ -84,7 +84,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         private DateTime _lastUpdated;
 
-        private SemanticVersion _latestVersion;
+        private NuGetVersion _latestVersion;
 
         private string _licenseUrl = string.Empty;
 
@@ -114,7 +114,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         private string _title;
 
-        private SemanticVersion _version;
+        private NuGetVersion _version;
 
         private int _versionDownloadCount;
 
@@ -314,7 +314,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             set { SetPropertyValue(ref _language, value); }
         }
 
-        public SemanticVersion LatestVersion
+        public NuGetVersion LatestVersion
         {
             get { return _latestVersion; }
             set { SetPropertyValue(ref _latestVersion, value); }
@@ -404,7 +404,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             set { SetPropertyValue(ref _title, value); }
         }
 
-        public SemanticVersion Version
+        public NuGetVersion Version
         {
             get { return _version; }
             set { SetPropertyValue(ref _version, value); }

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -68,15 +68,13 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         private string _id;
 
-        private bool _isAbsoluteLatestVersion;
+        private bool _isOutdated;
 
         private bool _isInstalled;
 
         private bool _isPinned;
 
         private bool _isSideBySide;
-
-        private bool _isLatestVersion;
 
         private bool _isPrerelease;
 
@@ -173,7 +171,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         public bool IsUninstallAllowed => _allowedCommandsService.IsUninstallCommandAllowed;
 
-        public bool CanUpdate => IsInstalled && !IsPinned && !IsSideBySide && !IsLatestVersion;
+        public bool CanUpdate => IsInstalled && !IsPinned && !IsSideBySide && IsOutdated;
 
         public bool IsUpgradeAllowed => _allowedCommandsService.IsUpgradeCommandAllowed;
 
@@ -232,12 +230,6 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             get { return Id.ToLowerInvariant(); }
         }
 
-        public bool IsAbsoluteLatestVersion
-        {
-            get { return _isAbsoluteLatestVersion; }
-            set { SetPropertyValue(ref _isAbsoluteLatestVersion, value); }
-        }
-
         public bool IsInstalled
         {
             get
@@ -286,16 +278,16 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             }
         }
 
-        public bool IsLatestVersion
+        public bool IsOutdated
         {
             get
             {
-                return _isLatestVersion;
+                return _isOutdated;
             }
 
             set
             {
-                if (SetPropertyValue(ref _isLatestVersion, value))
+                if (SetPropertyValue(ref _isOutdated, value))
                 {
                     NotifyPropertyChanged(nameof(CanUpdate));
                 }
@@ -713,7 +705,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             }
 
             LatestVersion = message.Version;
-            IsLatestVersion = false;
+            IsOutdated = true;
         }
 
         private async Task InstallPackage(string version, AdvancedInstall advancedOptions = null)

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -27,6 +27,7 @@ using ChocolateyGui.Common.Windows.Services;
 using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.Utilities.Extensions;
 using NuGet;
+using NuGet.Packaging;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -321,10 +322,6 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                         if (installed.Any(package => string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase)))
                         {
                             p.IsInstalled = true;
-                        }
-                        if (outdated.Any(package => string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase)))
-                        {
-                            p.IsLatestVersion = false;
                         }
 
                         Packages.Add(Mapper.Map<IPackageViewModel>(p));

--- a/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
@@ -80,7 +80,7 @@
                 <MultiDataTrigger>
                     <MultiDataTrigger.Conditions>
                         <Condition Binding="{Binding IsInstalled, Mode=OneWay}" Value="True" />
-                        <Condition Binding="{Binding IsLatestVersion, Mode=OneWay}" Value="False" />
+                        <Condition Binding="{Binding IsOutdated, Mode=OneWay}" Value="True" />
                     </MultiDataTrigger.Conditions>
                     <Setter TargetName="OutOfDateOverlay" Property="Visibility" Value="Visible" />
                 </MultiDataTrigger>
@@ -317,7 +317,7 @@
                                                 <DataTemplate DataType="{x:Type items:IPackageViewModel}">
                                                     <Grid Background="{DynamicResource {x:Static theming:ChocolateyBrushes.OutOfDateKey}}"
                                                           TextElement.Foreground="{DynamicResource {x:Static theming:ChocolateyBrushes.OutOfDateForegroundKey}}"
-                                                          Visibility="{Binding IsLatestVersion, Converter={StaticResource BooleanToVisibilityInverted}}"
+                                                          Visibility="{Binding IsOutdated, Converter={StaticResource BooleanToVisibility}}"
                                                           HorizontalAlignment="Stretch"
                                                           VerticalAlignment="Stretch">
                                                         <Grid.ColumnDefinitions>

--- a/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
@@ -257,7 +257,7 @@
                 <TextBlock.Visibility>
                     <MultiBinding Converter="{StaticResource MultiBooleanAndToVisibility}">
                         <Binding Path="IsInstalled" />
-                        <Binding Path="IsLatestVersion" Converter="{StaticResource BooleanInverter}" />
+                        <Binding Path="IsOutdated" />
                     </MultiBinding>
                 </TextBlock.Visibility>
             </TextBlock>
@@ -277,7 +277,7 @@
                 <TextBlock.Visibility>
                     <MultiBinding Converter="{StaticResource MultiBooleanAndToVisibility}">
                         <Binding Path="IsInstalled" />
-                        <Binding Path="IsLatestVersion" />
+                        <Binding Path="IsOutdated" Converter="{StaticResource BooleanInverter}" />
                     </MultiBinding>
                 </TextBlock.Visibility>
             </TextBlock>

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -287,14 +287,14 @@
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding IsInstalled, Mode=OneWay}" Value="True" />
-                            <Condition Binding="{Binding IsLatestVersion, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding IsOutdated, Mode=OneWay}" Value="False" />
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="IsInstalledOverlay" Property="Visibility" Value="Visible" />
                     </MultiDataTrigger>
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding IsInstalled, Mode=OneWay}" Value="True" />
-                            <Condition Binding="{Binding IsLatestVersion, Mode=OneWay}" Value="False" />
+                            <Condition Binding="{Binding IsOutdated, Mode=OneWay}" Value="True" />
                         </MultiDataTrigger.Conditions>
                         <Setter TargetName="OutOfDateOverlay" Property="Visibility" Value="Visible" />
                     </MultiDataTrigger>

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -5,7 +5,7 @@
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net40" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net48" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net48" />
-  <package id="chocolatey.lib" version="1.0.0" targetFramework="net48" />
+  <package id="chocolatey.lib" version="2.0.0-alpha-20230124" targetFramework="net48" />
   <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
   <package id="Fizzler" version="1.2.0" targetFramework="net48" />
   <package id="HarfBuzzSharp" version="2.6.1.4" targetFramework="net48" />

--- a/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
+++ b/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
@@ -54,10 +54,8 @@
     <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=1.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.1.0.0\lib\chocolatey.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="chocolatey, Version=2.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.2.0.0-alpha-20230124\lib\net48\chocolatey.dll</HintPath>
     </Reference>
     <Reference Include="LiteDB, Version=5.0.5.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.5.0.5\lib\net45\LiteDB.dll</HintPath>

--- a/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
+++ b/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
@@ -166,7 +166,7 @@
     <Compile Include="Models\PowerShellOutputLine.cs" />
     <Compile Include="Models\PurgeCommandConfiguration.cs" />
     <Compile Include="Models\PurgeCommandType.cs" />
-    <Compile Include="Models\SemanticVersionTypeConverter.cs" />
+    <Compile Include="Models\NuGetVersionTypeConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>

--- a/Source/ChocolateyGui.Common/Models/Messages/PackageChangedMessage.cs
+++ b/Source/ChocolateyGui.Common/Models/Messages/PackageChangedMessage.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Models.Messages
 {
@@ -20,7 +20,7 @@ namespace ChocolateyGui.Common.Models.Messages
 
     public class PackageChangedMessage
     {
-        public PackageChangedMessage(string id, PackageChangeType changeType, SemanticVersion version = null)
+        public PackageChangedMessage(string id, PackageChangeType changeType, NuGetVersion version = null)
         {
             Id = id;
             ChangeType = changeType;
@@ -29,7 +29,7 @@ namespace ChocolateyGui.Common.Models.Messages
 
         public string Id { get; }
 
-        public SemanticVersion Version { get; }
+        public NuGetVersion Version { get; }
 
         public PackageChangeType ChangeType { get; }
     }

--- a/Source/ChocolateyGui.Common/Models/Messages/PackageHasUpdateMessage.cs
+++ b/Source/ChocolateyGui.Common/Models/Messages/PackageHasUpdateMessage.cs
@@ -5,13 +5,13 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Models.Messages
 {
     public class PackageHasUpdateMessage
     {
-        public PackageHasUpdateMessage(string id, SemanticVersion version)
+        public PackageHasUpdateMessage(string id, NuGetVersion version)
         {
             Id = id;
             Version = version;
@@ -19,6 +19,6 @@ namespace ChocolateyGui.Common.Models.Messages
 
         public string Id { get; }
 
-        public SemanticVersion Version { get; set; }
+        public NuGetVersion Version { get; set; }
     }
 }

--- a/Source/ChocolateyGui.Common/Models/NuGetVersionTypeConverter.cs
+++ b/Source/ChocolateyGui.Common/Models/NuGetVersionTypeConverter.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright company="Chocolatey" file="SemanticVersionTypeConverter.cs">
+// <copyright company="Chocolatey" file="NuGetVersionTypeConverter.cs">
 //   Copyright 2017 - Present Chocolatey Software, LLC
 //   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
 // </copyright>
@@ -8,11 +8,11 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Models
 {
-    public class SemanticVersionTypeConverter : TypeConverter
+    public class NuGetVersionTypeConverter : TypeConverter
     {
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
@@ -22,8 +22,8 @@ namespace ChocolateyGui.Common.Models
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             var version = value as string;
-            SemanticVersion semanticVersion;
-            if (version != null && SemanticVersion.TryParse(version, out semanticVersion))
+            NuGetVersion semanticVersion;
+            if (version != null && NuGetVersion.TryParse(version, out semanticVersion))
             {
                 return semanticVersion;
             }

--- a/Source/ChocolateyGui.Common/Models/OutdatedPackage.cs
+++ b/Source/ChocolateyGui.Common/Models/OutdatedPackage.cs
@@ -6,7 +6,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System.Xml.Serialization;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Models
 {
@@ -17,9 +17,9 @@ namespace ChocolateyGui.Common.Models
         public string VersionString { get; set;  }
 
         [XmlIgnore]
-        public SemanticVersion Version
+        public NuGetVersion Version
         {
-            get { return new SemanticVersion(VersionString); }
+            get { return NuGetVersion.Parse(VersionString); }
         }
     }
 }

--- a/Source/ChocolateyGui.Common/Models/Package.cs
+++ b/Source/ChocolateyGui.Common/Models/Package.cs
@@ -28,15 +28,11 @@ namespace ChocolateyGui.Common.Models
 
         public string Id { get; set; }
 
-        public bool IsAbsoluteLatestVersion { get; set; }
-
         public bool IsInstalled { get; set; }
 
         public bool IsPinned { get; set; }
 
         public bool IsSideBySide { get; set; }
-
-        public bool IsLatestVersion { get; set; }
 
         public bool IsPrerelease { get; set; }
 

--- a/Source/ChocolateyGui.Common/Models/Package.cs
+++ b/Source/ChocolateyGui.Common/Models/Package.cs
@@ -6,7 +6,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Models
 {
@@ -72,7 +72,7 @@ namespace ChocolateyGui.Common.Models
 
         public string Title { get; set; }
 
-        public SemanticVersion Version { get; set; }
+        public NuGetVersion Version { get; set; }
 
         public int VersionDownloadCount { get; set; }
     }

--- a/Source/ChocolateyGui.Common/Services/IChocolateyService.cs
+++ b/Source/ChocolateyGui.Common/Services/IChocolateyService.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using ChocolateyGui.Common.Models;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.Services
 {
@@ -25,7 +25,7 @@ namespace ChocolateyGui.Common.Services
 
         Task<Package> GetByVersionAndIdAsync(string id, string version, bool isPrerelease);
 
-        Task<List<SemanticVersion>> GetAvailableVersionsForPackageIdAsync(string id, int page, int pageSize, bool includePreRelease);
+        Task<List<NuGetVersion>> GetAvailableVersionsForPackageIdAsync(string id, int page, int pageSize, bool includePreRelease);
 
         Task<PackageOperationResult> InstallPackage(
             string id,

--- a/Source/ChocolateyGui.Common/ViewModels/Items/IPackageViewModel.cs
+++ b/Source/ChocolateyGui.Common/ViewModels/Items/IPackageViewModel.cs
@@ -7,7 +7,7 @@
 
 using System;
 using System.Threading.Tasks;
-using NuGet;
+using NuGet.Versioning;
 
 namespace ChocolateyGui.Common.ViewModels.Items
 {
@@ -45,7 +45,7 @@ namespace ChocolateyGui.Common.ViewModels.Items
 
         string Language { get; set; }
 
-        SemanticVersion LatestVersion { get; }
+        NuGetVersion LatestVersion { get; }
 
         string LicenseUrl { get; set; }
 
@@ -75,7 +75,7 @@ namespace ChocolateyGui.Common.ViewModels.Items
 
         string Title { get; set; }
 
-        SemanticVersion Version { get; set; }
+        NuGetVersion Version { get; set; }
 
         int VersionDownloadCount { get; set; }
 

--- a/Source/ChocolateyGui.Common/ViewModels/Items/IPackageViewModel.cs
+++ b/Source/ChocolateyGui.Common/ViewModels/Items/IPackageViewModel.cs
@@ -31,15 +31,13 @@ namespace ChocolateyGui.Common.ViewModels.Items
 
         string Id { get; set; }
 
-        bool IsAbsoluteLatestVersion { get; set; }
+        bool IsOutdated { get; set; }
 
         bool IsInstalled { get; set; }
 
         bool IsPinned { get; set; }
 
         bool IsSideBySide { get; set; }
-
-        bool IsLatestVersion { get; set; }
 
         bool IsPrerelease { get; set; }
 

--- a/Source/ChocolateyGui.Common/packages.config
+++ b/Source/ChocolateyGui.Common/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
   <package id="AutoMapper" version="7.0.1" targetFramework="net48" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
-  <package id="chocolatey.lib" version="1.0.0" targetFramework="net48" />
+  <package id="chocolatey.lib" version="2.0.0-alpha-20230124" targetFramework="net48" />
   <package id="LiteDB" version="5.0.5" targetFramework="net452" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -113,10 +113,8 @@
     <Reference Include="Caliburn.Micro.Platform.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=1.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.1.0.0\lib\chocolatey.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="chocolatey, Version=2.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.2.0.0-alpha-20230124\lib\net48\chocolatey.dll</HintPath>
     </Reference>
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.4.4.0\lib\net462\ControlzEx.dll</HintPath>

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -5,7 +5,7 @@
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net452" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
-  <package id="chocolatey.lib" version="1.0.0" targetFramework="net48" />
+  <package id="chocolatey.lib" version="2.0.0-alpha-20230124" targetFramework="net48" />
   <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
   <package id="Fizzler" version="1.2.0" targetFramework="net48" />
   <package id="HarfBuzzSharp" version="2.6.1.4" targetFramework="net48" />

--- a/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
+++ b/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
@@ -56,10 +56,8 @@
     <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="chocolatey, Version=1.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\chocolatey.lib.1.0.0\lib\chocolatey.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="chocolatey, Version=2.0.0.0, Culture=neutral, PublicKeyToken=79d02ea9cad655eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\chocolatey.lib.2.0.0-alpha-20230124\lib\net48\chocolatey.dll</HintPath>
     </Reference>
     <Reference Include="LiteDB, Version=5.0.5.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.5.0.5\lib\net45\LiteDB.dll</HintPath>

--- a/Source/ChocolateyGuiCli/packages.config
+++ b/Source/ChocolateyGuiCli/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.1" targetFramework="net452" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net452" />
-  <package id="chocolatey.lib" version="1.0.0" targetFramework="net48" />
+  <package id="chocolatey.lib" version="2.0.0-alpha-20230124" targetFramework="net48" />
   <package id="LiteDB" version="5.0.5" targetFramework="net452" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
   <package id="Serilog" version="2.5.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

Update `chocolatey.lib` to a build using the new NuGet assemblies. 

Changes various items to adjust to breaking API changes in the new library version. Specifically `SemanticVersion` was replaced with `NuGetVersion`, and changes to adjust for the move from `IPackage` to `IPackageMetadata` and `IPackageSearchMetadata` were the main things required.

## Motivation and Context

ChocolateyGUI will need to work with Chocolatey v2.0.0

## Testing

- Opened ChocolateyGUI
- Went to CCR feed and looked at default page (paging and ordering known broken)
- Searched on CCR feed
- Viewed details of a package.
- Added local feed with outdated wget package available
- Viewed local feed
- Installed wget from that local feed
- Noted that wget was correctly marked as outdated
- Updated wget from CCR
- Pinned and unpinned wget
- Viewed details for wget
- Uninstalled wget

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Preliminary work for #974
