### PR TITLE
(#980) When using debug install, use assembly directory for install location

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NuGetVersionToString.cs
+++ b/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NuGetVersionToString.cs
@@ -1,4 +1,11 @@
-﻿namespace ChocolateyGui.Common.Windows.Utilities.Converters
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Chocolatey" file="NuGetVersionToString.cs">
+//   Copyright 2017 - Present Chocolatey Software, LLC
+//   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ChocolateyGui.Common.Windows.Utilities.Converters
 {
     using System;
     using System.Collections.Generic;

--- a/Source/ChocolateyGui.Common/Providers/ChocolateyConfigurationProvider.cs
+++ b/Source/ChocolateyGui.Common/Providers/ChocolateyConfigurationProvider.cs
@@ -29,6 +29,9 @@ namespace ChocolateyGui.Common.Providers
 
         private void GetChocolateyInstallLocation()
         {
+#if DEBUG
+            ChocolateyInstall = _fileSystem.GetDirectoryName(_fileSystem.GetCurrentAssemblyPath());
+#else
             ChocolateyInstall = Environment.GetEnvironmentVariable("ChocolateyInstall");
             if (string.IsNullOrWhiteSpace(ChocolateyInstall))
             {
@@ -46,16 +49,21 @@ namespace ChocolateyGui.Common.Providers
             {
                 ChocolateyInstall = string.Empty;
             }
+#endif
         }
 
         private void DetermineIfChocolateyExecutableIsBeingUsed()
         {
+#if DEBUG
+            IsChocolateyExecutableBeingUsed = true;
+#else
             var exePath = _fileSystem.CombinePaths(ChocolateyInstall, "choco.exe");
 
             if (_fileSystem.FileExists(exePath))
             {
                 IsChocolateyExecutableBeingUsed = true;
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes
This sets the Chocolatey install directory to the current assembly directory when built as a debug build. 

If a debug build is in use, then Chocolatey GUI is using the chocolatey lib assembly, so true can be returned in all cases.

## Motivation and Context

This allows correctly getting the location of remembered arguments from the debug installed package(s) instead of from the system-wide install of Chocolatey.

## Testing

1. Build a debug version of Chocolatey GUI
1. F5 run from Visual Studio
1. Advanced install curl with package parameter(s)
1. View the remembered arguments.
1. Validate that they are coming from the local/debug install of curl, rather than from the system wide install.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #980
