### PR TITLE
(#993) (ENGTASKS-2347) Run integration tests only on scheduled builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,9 +3,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-
-version = "2021.2"
 
 project {
     buildType(ChocolateyGUI)
@@ -62,13 +61,27 @@ object ChocolateyGUI : BuildType({
 
         script {
             name = "Call Cake"
-            scriptContent = "call build.official.bat"
+            scriptContent = scriptContent = """
+                IF "%teamcity.build.triggeredBy%" == "Schedule Trigger" (SET TestType=all) ELSE (SET TestType=unit)
+                call build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=%%TestType%% --shouldRunOpenCover=false
+            """.trimIndent()
         }
     }
 
     triggers {
         vcs {
             branchFilter = ""
+        }
+        schedule {
+            schedulingPolicy = daily {
+                hour = 2
+                minute = 0
+            }
+            branchFilter = """
+                +:<default>
+            """.trimIndent()
+            triggerBuild = always()
+			withPendingChangesOnly = false
         }
     }
 


### PR DESCRIPTION
NOTE: This PR should not be merged until Chocolatey CLI v2.0.0 has been released. This repo also currently does not differentiate between unit and integration tests (if I'm reading things correctly), so merging may need to wait until that is the case.

## Description Of Changes

This PR adds a schedule trigger to the TeamCity build, and also adjust the build so that it selects which tests to run based on how the build was triggered.

It also adjusts the GitHub workflow for pushes and pull requests to only run unit tests.

## Motivation and Context

Integration tests take a long time to run, and do not need to be run on every commit. Reducing the tests run on each commit to only unit tests will speed up the feedback loop.

Running full integration tests on a schedule means that we still benefit from the coverage they give without slowing down the "in the moment" feedback.

## Testing

Equivalent Kotlin changes [submitted to chocolatey/choco](https://github.com/chocolatey/choco/pull/3118) have been tested on a non-production TeamCity instance.

### Operating Systems Testing

N/A

## Change Types Made

N/A

## Change Checklist

N/A

## Related Issue

- Fixes #993
- ENGTASKS-2347