### PR TITLE
(#1000) Do not display sensitive persisted package arguments

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
+++ b/Source/ChocolateyGui.Common.Windows/Bootstrapper.cs
@@ -37,13 +37,13 @@ namespace ChocolateyGui.Common.Windows
         private static readonly IFileSystem _fileSystem = new DotNetFileSystem();
 
 #pragma warning disable SA1202
-        public static readonly string ChocolateyGuiInstallLocation = _fileSystem.get_directory_name(_fileSystem.get_current_assembly_path());
+        public static readonly string ChocolateyGuiInstallLocation = _fileSystem.GetDirectoryName(_fileSystem.GetCurrentAssemblyPath());
         public static readonly string ChocolateyInstallEnvironmentVariableName = "ChocolateyInstall";
-        public static readonly string ChocolateyInstallLocation = System.Environment.GetEnvironmentVariable(ChocolateyInstallEnvironmentVariableName) ?? _fileSystem.get_directory_name(_fileSystem.get_current_assembly_path());
-        public static readonly string LicensedGuiAssemblyLocation = _fileSystem.combine_paths(ChocolateyInstallLocation, "extensions", "chocolateygui", "chocolateygui.licensed.dll");
+        public static readonly string ChocolateyInstallLocation = System.Environment.GetEnvironmentVariable(ChocolateyInstallEnvironmentVariableName) ?? _fileSystem.GetDirectoryName(_fileSystem.GetCurrentAssemblyPath());
+        public static readonly string LicensedGuiAssemblyLocation = _fileSystem.CombinePaths(ChocolateyInstallLocation, "extensions", "chocolateygui", "chocolateygui.licensed.dll");
 
-        public static readonly string ChocolateyGuiCommonAssemblyLocation = _fileSystem.combine_paths(ChocolateyGuiInstallLocation, "ChocolateyGui.Common.dll");
-        public static readonly string ChocolateyGuiCommonWindowsAssemblyLocation = _fileSystem.combine_paths(ChocolateyGuiInstallLocation, "ChocolateyGui.Common.Windows.dll");
+        public static readonly string ChocolateyGuiCommonAssemblyLocation = _fileSystem.CombinePaths(ChocolateyGuiInstallLocation, "ChocolateyGui.Common.dll");
+        public static readonly string ChocolateyGuiCommonWindowsAssemblyLocation = _fileSystem.CombinePaths(ChocolateyGuiInstallLocation, "ChocolateyGui.Common.Windows.dll");
 
         public static readonly string ChocolateyGuiCommonAssemblySimpleName = "ChocolateyGui.Common";
         public static readonly string ChocolateyGuiCommonWindowsAssemblySimpleName = "ChocolateyGui.Common.Windows";

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -60,7 +60,7 @@ namespace ChocolateyGui.Common.Windows.Services
             _configService = configService;
             _choco = Lets.GetChocolatey(initializeLogging: false).SetCustomLogging(new SerilogLogger(Logger, _progressService), logExistingMessages: false, addToExistingLoggers: true);
 
-            _localAppDataPath = _fileSystem.combine_paths(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "Chocolatey GUI");
+            _localAppDataPath = _fileSystem.CombinePaths(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "Chocolatey GUI");
         }
 
         public Task<bool> IsElevated()
@@ -73,7 +73,7 @@ namespace ChocolateyGui.Common.Windows.Services
             _choco.Set(
                 config =>
                     {
-                        config.CommandName = CommandNameType.list.ToString();
+                        config.CommandName = CommandNameType.List.ToString();
                     });
 
             var chocoConfig = _choco.GetConfiguration();
@@ -91,7 +91,7 @@ namespace ChocolateyGui.Common.Windows.Services
             else
             {
                 var nugetService = _choco.Container().GetInstance<INugetService>();
-                var packages = await Task.Run(() => nugetService.list_run(chocoConfig));
+                var packages = await Task.Run(() => nugetService.List(chocoConfig));
                 return packages
                     .Select(package => GetMappedPackage(_choco, package, _mapper, true))
                     .ToArray();
@@ -107,7 +107,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 return new List<OutdatedPackage>();
             }
 
-            var outdatedPackagesFile = _fileSystem.combine_paths(_localAppDataPath, "outdatedPackages.xml");
+            var outdatedPackagesFile = _fileSystem.CombinePaths(_localAppDataPath, "outdatedPackages.xml");
 
             var outdatedPackagesCacheDurationInMinutesSetting = _configService.GetEffectiveConfiguration().OutdatedPackagesCacheDurationInMinutes;
             int outdatedPackagesCacheDurationInMinutes = 0;
@@ -116,9 +116,9 @@ namespace ChocolateyGui.Common.Windows.Services
                 int.TryParse(outdatedPackagesCacheDurationInMinutesSetting, out outdatedPackagesCacheDurationInMinutes);
             }
 
-            if (_fileSystem.file_exists(outdatedPackagesFile) && (DateTime.Now - _fileSystem.get_file_modified_date(outdatedPackagesFile)).TotalMinutes < outdatedPackagesCacheDurationInMinutes)
+            if (_fileSystem.FileExists(outdatedPackagesFile) && (DateTime.Now - _fileSystem.GetFileModifiedDate(outdatedPackagesFile)).TotalMinutes < outdatedPackagesCacheDurationInMinutes)
             {
-                return _xmlService.deserialize<List<OutdatedPackage>>(outdatedPackagesFile);
+                return _xmlService.Deserialize<List<OutdatedPackage>>(outdatedPackagesFile);
             }
             else
             {
@@ -140,7 +140,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 if (chocoConfig.Sources != null)
                 {
                     var nugetService = choco.Container().GetInstance<INugetService>();
-                    var packages = await Task.Run(() => nugetService.upgrade_noop(chocoConfig, null));
+                    var packages = await Task.Run(() => nugetService.UpgradeDryRun(chocoConfig, null));
                     var results = packages
                         .Where(p => !p.Value.Inconclusive)
                         .Select(p => new OutdatedPackage
@@ -154,12 +154,12 @@ namespace ChocolateyGui.Common.Windows.Services
                         // packages, when the serialized file has become old/stale, so we NEED the file to be re-written
                         // when this check is done, so that it isn't always doing the check. Therefore, when we are
                         // getting ready to serialize the list of outdated packages, if the file already exists, delete it.
-                        if (_fileSystem.file_exists(outdatedPackagesFile))
+                        if (_fileSystem.FileExists(outdatedPackagesFile))
                         {
-                            _fileSystem.delete_file(outdatedPackagesFile);
+                            _fileSystem.DeleteFile(outdatedPackagesFile);
                         }
 
-                        _xmlService.serialize(results, outdatedPackagesFile);
+                        _xmlService.Serialize(results, outdatedPackagesFile);
                     }
                     catch (Exception ex)
                     {
@@ -189,7 +189,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 choco.Set(
                     config =>
                         {
-                            config.CommandName = CommandNameType.install.ToString();
+                            config.CommandName = CommandNameType.Install.ToString();
                             config.PackageNames = id;
                             config.Features.UsePackageExitCodes = false;
 
@@ -369,7 +369,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 choco.Set(
                     config =>
                         {
-                            config.CommandName = CommandNameType.uninstall.ToString();
+                            config.CommandName = CommandNameType.Uninstall.ToString();
                             config.PackageNames = id;
                             config.Features.UsePackageExitCodes = false;
 
@@ -392,7 +392,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 choco.Set(
                     config =>
                         {
-                            config.CommandName = CommandNameType.upgrade.ToString();
+                            config.CommandName = CommandNameType.Upgrade.ToString();
                             config.PackageNames = id;
                             config.Features.UsePackageExitCodes = false;
                         });
@@ -409,7 +409,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     config =>
                         {
                             config.CommandName = "pin";
-                            config.PinCommand.Command = PinCommandType.add;
+                            config.PinCommand.Command = PinCommandType.Add;
                             config.PinCommand.Name = id;
                             config.Version = version;
                             config.Sources = ApplicationParameters.PackagesLocation;
@@ -436,7 +436,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     config =>
                         {
                             config.CommandName = "pin";
-                            config.PinCommand.Command = PinCommandType.remove;
+                            config.PinCommand.Command = PinCommandType.Remove;
                             config.PinCommand.Name = id;
                             config.Version = version;
                             config.Sources = ApplicationParameters.PackagesLocation;
@@ -474,7 +474,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     config =>
                     {
                         config.CommandName = "feature";
-                        config.FeatureCommand.Command = feature.Enabled ? chocolatey.infrastructure.app.domain.FeatureCommandType.enable : chocolatey.infrastructure.app.domain.FeatureCommandType.disable;
+                        config.FeatureCommand.Command = feature.Enabled ? chocolatey.infrastructure.app.domain.FeatureCommandType.Enable : chocolatey.infrastructure.app.domain.FeatureCommandType.Disable;
                         config.FeatureCommand.Name = feature.Name;
                     });
 
@@ -497,7 +497,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     config =>
                         {
                             config.CommandName = "config";
-                            config.ConfigCommand.Command = chocolatey.infrastructure.app.domain.ConfigCommandType.set;
+                            config.ConfigCommand.Command = chocolatey.infrastructure.app.domain.ConfigCommandType.Set;
                             config.ConfigCommand.Name = setting.Key;
                             config.ConfigCommand.ConfigValue = setting.Value;
                         });
@@ -514,7 +514,7 @@ namespace ChocolateyGui.Common.Windows.Services
             var config = await GetConfigFile();
             var allSources = config.Sources.Select(_mapper.Map<ChocolateySource>).ToArray();
 
-            var filteredSourceIds = _configSettingsService.source_list(_choco.GetConfiguration()).Select(s => s.Id).ToArray();
+            var filteredSourceIds = _configSettingsService.ListSources(_choco.GetConfiguration()).Select(s => s.Id).ToArray();
 
             var mappedSources = allSources.Where(s => filteredSourceIds.Contains(s.Id)).ToArray();
             return mappedSources;
@@ -528,7 +528,7 @@ namespace ChocolateyGui.Common.Windows.Services
                     config =>
                     {
                         config.CommandName = "source";
-                        config.SourceCommand.Command = SourceCommandType.add;
+                        config.SourceCommand.Command = SourceCommandType.Add;
                         config.SourceCommand.Name = source.Id;
                         config.Sources = source.Value;
                         config.SourceCommand.Username = source.UserName;
@@ -560,7 +560,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 config =>
                 {
                     config.CommandName = "source";
-                    config.SourceCommand.Command = SourceCommandType.disable;
+                    config.SourceCommand.Command = SourceCommandType.Disable;
                     config.SourceCommand.Name = id;
                 });
 
@@ -573,7 +573,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 config =>
                 {
                     config.CommandName = "source";
-                    config.SourceCommand.Command = SourceCommandType.enable;
+                    config.SourceCommand.Command = SourceCommandType.Enable;
                     config.SourceCommand.Name = id;
                 });
 
@@ -611,7 +611,7 @@ namespace ChocolateyGui.Common.Windows.Services
                         config =>
                         {
                             config.CommandName = "source";
-                            config.SourceCommand.Command = SourceCommandType.remove;
+                            config.SourceCommand.Command = SourceCommandType.Remove;
                             config.SourceCommand.Name = id;
                         });
 
@@ -646,7 +646,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 }
 
                 var packageInfoService = choco.Container().GetInstance<IChocolateyPackageInformationService>();
-                var packageInfo = packageInfoService.get_package_information(package.PackageMetadata);
+                var packageInfo = packageInfoService.Get(package.PackageMetadata);
                 mappedPackage.IsPinned = packageInfo.IsPinned;
                 mappedPackage.IsInstalled = !string.IsNullOrWhiteSpace(package.InstallLocation) || forceInstalled;
 
@@ -714,7 +714,7 @@ namespace ChocolateyGui.Common.Windows.Services
             var xmlService = _choco.Container().GetInstance<IXmlService>();
             var config =
                 await Task.Run(
-                    () => xmlService.deserialize<ConfigFileSettings>(chocolatey.infrastructure.app.ApplicationParameters.GlobalConfigFileLocation));
+                    () => xmlService.Deserialize<ConfigFileSettings>(chocolatey.infrastructure.app.ApplicationParameters.GlobalConfigFileLocation));
             return config;
         }
     }

--- a/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/PackageArgumentsService.cs
@@ -82,7 +82,7 @@ namespace ChocolateyGui.Common.Windows.Services
 
             foreach (var packageArgument in packageArgumentsSplit.or_empty_list_if_null())
             {
-                var isSensitiveArgument = sensitiveArgs && ArgumentsUtility.arguments_contain_sensitive_information(packageArgument);
+                var isSensitiveArgument = sensitiveArgs && ArgumentsUtility.arguments_contain_sensitive_information(string.Concat("--", packageArgument));
 
                 var packageArgumentSplit =
                     packageArgument.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries);

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
@@ -440,7 +440,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         private void BrowseLogFile(object value)
         {
-            var filter = "{0}|{1}|{2}".format_with(
+            var filter = "{0}|{1}|{2}".FormatWith(
                 L(nameof(Resources.FilePicker_LogFiles)) + "|*.log;*.klg",
                 L(nameof(Resources.FilePicker_TextFiles)) + "|*.txt;*.text;*.plain",
                 L(nameof(Resources.FilePicker_AllFiles)) + "|*.*");

--- a/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Views/ShellView.xaml.cs
@@ -65,7 +65,7 @@ namespace ChocolateyGui.Common.Windows.Views
 
             // Certain things like Cef (our markdown browser engine) get unhappy when GUI is started from a different cwd.
             // If we're in a different one, reset it to our app files directory.
-            if (_fileSystem.get_directory_name(Environment.CurrentDirectory) != Bootstrapper.ApplicationFilesPath)
+            if (_fileSystem.GetDirectoryName(Environment.CurrentDirectory) != Bootstrapper.ApplicationFilesPath)
             {
                 Environment.CurrentDirectory = Bootstrapper.ApplicationFilesPath;
             }

--- a/Source/ChocolateyGui.Common/Commands/ConfigCommand.cs
+++ b/Source/ChocolateyGui.Common/Commands/ConfigCommand.cs
@@ -35,11 +35,11 @@ namespace ChocolateyGui.Common.Commands
                 .Add(
                     "name=",
                     L(nameof(Resources.ConfigCommand_NameOption)),
-                    option => configuration.ConfigCommand.Name = option.remove_surrounding_quotes())
+                    option => configuration.ConfigCommand.Name = option.UnquoteSafe())
                 .Add(
                     "value=",
                     L(nameof(Resources.ConfigCommand_ValueOption)),
-                    option => configuration.ConfigCommand.ConfigValue = option.remove_surrounding_quotes())
+                    option => configuration.ConfigCommand.ConfigValue = option.UnquoteSafe())
                 .Add(
                     "g|global",
                     L(nameof(Resources.GlobalOption)),
@@ -51,7 +51,7 @@ namespace ChocolateyGui.Common.Commands
             configuration.Input = string.Join(" ", unparsedArguments);
 
             var command = ConfigCommandType.Unknown;
-            var unparsedCommand = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault().to_string().Replace("-", string.Empty);
+            var unparsedCommand = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault().ToStringSafe().Replace("-", string.Empty);
             Enum.TryParse(unparsedCommand, true, out command);
             if (command == ConfigCommandType.Unknown)
             {
@@ -87,14 +87,14 @@ namespace ChocolateyGui.Common.Commands
             if (configuration.ConfigCommand.Command != ConfigCommandType.List &&
                 string.IsNullOrWhiteSpace(configuration.ConfigCommand.Name))
             {
-                Logger.Error(L(nameof(Resources.ConfigCommand_MissingNameOptionError), configuration.ConfigCommand.Command.to_string(), "--name"));
+                Logger.Error(L(nameof(Resources.ConfigCommand_MissingNameOptionError), configuration.ConfigCommand.Command.ToStringSafe(), "--name"));
                 Environment.Exit(-1);
             }
 
             if (configuration.ConfigCommand.Command == ConfigCommandType.Set &&
                 string.IsNullOrWhiteSpace(configuration.ConfigCommand.ConfigValue))
             {
-                Logger.Error(L(nameof(Resources.ConfigCommand_MissingValueOptionError), configuration.ConfigCommand.Command.to_string(), "--value"));
+                Logger.Error(L(nameof(Resources.ConfigCommand_MissingValueOptionError), configuration.ConfigCommand.Command.ToStringSafe(), "--value"));
                 Environment.Exit(-1);
             }
         }

--- a/Source/ChocolateyGui.Common/Commands/FeatureCommand.cs
+++ b/Source/ChocolateyGui.Common/Commands/FeatureCommand.cs
@@ -35,7 +35,7 @@ namespace ChocolateyGui.Common.Commands
                 .Add(
                     "n=|name=",
                     L(nameof(Resources.FeatureCommand_NameOption)),
-                    option => configuration.FeatureCommand.Name = option.remove_surrounding_quotes())
+                    option => configuration.FeatureCommand.Name = option.UnquoteSafe())
                 .Add(
                     "g|global",
                     L(nameof(Resources.GlobalOption)),
@@ -72,7 +72,7 @@ namespace ChocolateyGui.Common.Commands
         {
             if (configuration.FeatureCommand.Command != FeatureCommandType.List && string.IsNullOrWhiteSpace(configuration.FeatureCommand.Name))
             {
-                Logger.Error(L(nameof(Resources.FeatureCommand_MissingNameOptionError), configuration.FeatureCommand.Command.to_string(), "--name"));
+                Logger.Error(L(nameof(Resources.FeatureCommand_MissingNameOptionError), configuration.FeatureCommand.Command.ToStringSafe(), "--name"));
                 Environment.Exit(-1);
             }
         }

--- a/Source/ChocolateyGui.Common/Commands/GenericRunner.cs
+++ b/Source/ChocolateyGui.Common/Commands/GenericRunner.cs
@@ -33,7 +33,7 @@ namespace ChocolateyGui.Common.Commands
 
             if (command != null)
             {
-                Logger.Debug("_ {0}:{1} - Normal Run Mode _".format_with("Chocolatey GUI", command.GetType().Name));
+                Logger.Debug("_ {0}:{1} - Normal Run Mode _".FormatWith("Chocolatey GUI", command.GetType().Name));
                 command.Run(configuration);
             }
         }
@@ -44,7 +44,7 @@ namespace ChocolateyGui.Common.Commands
             var command = commands.Where((c) =>
             {
                 var attributes = c.GetType().GetCustomAttributes(typeof(LocalizedCommandForAttribute), false);
-                return attributes.Cast<LocalizedCommandForAttribute>().Any(attribute => attribute.CommandName.is_equal_to(configuration.CommandName));
+                return attributes.Cast<LocalizedCommandForAttribute>().Any(attribute => attribute.CommandName.IsEqualTo(configuration.CommandName));
             }).FirstOrDefault();
 
             if (command == null)

--- a/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
+++ b/Source/ChocolateyGui.Common/Models/AppConfiguration.cs
@@ -124,7 +124,7 @@ DefaultToDarkMode: {17}
 HideThisPCSource: {18}
 PreventUsageOfUpdateAllButton: {19}
 SkipModalDialogConfirmation: {20}
-".format_with(
+".FormatWith(
                 OutdatedPackagesCacheDurationInMinutes,
                 DefaultSourceName,
                 UseLanguage,

--- a/Source/ChocolateyGui.Common/Providers/ChocolateyConfigurationProvider.cs
+++ b/Source/ChocolateyGui.Common/Providers/ChocolateyConfigurationProvider.cs
@@ -50,9 +50,9 @@ namespace ChocolateyGui.Common.Providers
 
         private void DetermineIfChocolateyExecutableIsBeingUsed()
         {
-            var exePath = _fileSystem.combine_paths(ChocolateyInstall, "choco.exe");
+            var exePath = _fileSystem.CombinePaths(ChocolateyInstall, "choco.exe");
 
-            if (_fileSystem.file_exists(exePath))
+            if (_fileSystem.FileExists(exePath))
             {
                 IsChocolateyExecutableBeingUsed = true;
             }

--- a/Source/ChocolateyGui.Common/Services/ChocolateyGuiCacheService.cs
+++ b/Source/ChocolateyGui.Common/Services/ChocolateyGuiCacheService.cs
@@ -22,7 +22,7 @@ namespace ChocolateyGui.Common.Services
             _fileStorageService = fileStorageService;
             _fileSystem = fileSystem;
 
-            _localAppDataPath = _fileSystem.combine_paths(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "Chocolatey GUI");
+            _localAppDataPath = _fileSystem.CombinePaths(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "Chocolatey GUI");
         }
 
         public void PurgeIcons()
@@ -32,17 +32,17 @@ namespace ChocolateyGui.Common.Services
 
         public void PurgeOutdatedPackages()
         {
-            var outdatedPackagesFile = _fileSystem.combine_paths(_localAppDataPath, "outdatedPackages.xml");
-            var outdatedPackagesBackupFile = _fileSystem.combine_paths(_localAppDataPath, "outdatedPackages.xml.backup");
+            var outdatedPackagesFile = _fileSystem.CombinePaths(_localAppDataPath, "outdatedPackages.xml");
+            var outdatedPackagesBackupFile = _fileSystem.CombinePaths(_localAppDataPath, "outdatedPackages.xml.backup");
 
-            if (_fileSystem.file_exists(outdatedPackagesFile))
+            if (_fileSystem.FileExists(outdatedPackagesFile))
             {
-                _fileSystem.delete_file(outdatedPackagesFile);
+                _fileSystem.DeleteFile(outdatedPackagesFile);
             }
 
-            if (_fileSystem.file_exists(outdatedPackagesBackupFile))
+            if (_fileSystem.FileExists(outdatedPackagesBackupFile))
             {
-                _fileSystem.delete_file(outdatedPackagesBackupFile);
+                _fileSystem.DeleteFile(outdatedPackagesBackupFile);
             }
         }
     }

--- a/Source/ChocolateyGui.Common/Services/ConfigService.cs
+++ b/Source/ChocolateyGui.Common/Services/ConfigService.cs
@@ -224,11 +224,11 @@ namespace ChocolateyGui.Common.Services
             {
                 if (configuration.RegularOutput)
                 {
-                    Logger.Information("{0} {1} - {2}".format_with(feature.Enabled ? "[x]" : "[ ]", feature.Title, feature.Description));
+                    Logger.Information("{0} {1} - {2}".FormatWith(feature.Enabled ? "[x]" : "[ ]", feature.Title, feature.Description));
                 }
                 else
                 {
-                    Logger.Information("{0}|{1}|{2}".format_with(feature.Title, L(!feature.Enabled ? nameof(Resources.FeatureCommand_Disabled) : nameof(Resources.FeatureCommand_Enabled)), feature.Description));
+                    Logger.Information("{0}|{1}|{2}".FormatWith(feature.Title, L(!feature.Enabled ? nameof(Resources.FeatureCommand_Disabled) : nameof(Resources.FeatureCommand_Enabled)), feature.Description));
                 }
             }
         }
@@ -265,11 +265,11 @@ namespace ChocolateyGui.Common.Services
             {
                 if (configuration.RegularOutput)
                 {
-                    Logger.Information("{0} = {1} - {2}".format_with(setting.Key, setting.Value, setting.Description));
+                    Logger.Information("{0} = {1} - {2}".FormatWith(setting.Key, setting.Value, setting.Description));
                 }
                 else
                 {
-                    Logger.Information("{0}|{1}|{2}".format_with(setting.Key, setting.Value, setting.Description));
+                    Logger.Information("{0}|{1}|{2}".FormatWith(setting.Key, setting.Value, setting.Description));
                 }
             }
         }
@@ -313,7 +313,7 @@ namespace ChocolateyGui.Common.Services
             var configProperty = GetProperty(configuration.ConfigCommand.Name, false);
             var configValue = (string)configProperty.GetValue(chosenAppConfiguration);
 
-            Logger.Information("{0}".format_with(configValue ?? string.Empty));
+            Logger.Information("{0}".FormatWith(configValue ?? string.Empty));
         }
 
         public void SetConfigValue(string key, string value)

--- a/Source/ChocolateyGui.Common/Startup/AutoFacConfiguration.cs
+++ b/Source/ChocolateyGui.Common/Startup/AutoFacConfiguration.cs
@@ -25,12 +25,12 @@ namespace ChocolateyGui.Common.Startup
             var builder = new ContainerBuilder();
             builder.RegisterAssemblyModules(System.Reflection.Assembly.GetCallingAssembly());
 
-            var license = License.validate_license();
+            var license = License.ValidateLicense();
             if (license.IsValid)
             {
                 if (File.Exists(licensedGuiAssemblyLocation))
                 {
-                    var licensedGuiAssembly = AssemblyResolution.resolve_or_load_assembly(
+                    var licensedGuiAssembly = AssemblyResolution.ResolveOrLoadAssembly(
                         chocolateyGuiAssemblySimpleName,
                         publicKey,
                         licensedGuiAssemblyLocation);
@@ -39,7 +39,7 @@ namespace ChocolateyGui.Common.Startup
                     {
                         license.AssemblyLoaded = true;
                         license.Assembly = licensedGuiAssembly;
-                        license.Version = VersionInformation.get_current_informational_version(licensedGuiAssembly);
+                        license.Version = VersionInformation.GetCurrentInformationalVersion(licensedGuiAssembly);
 
                         builder.RegisterAssemblyModules(licensedGuiAssembly.UnderlyingType);
                     }


### PR DESCRIPTION
## Description Of Changes

When the ability to show remembered arguments in Chocolatey GUI was
first introduced, code from the set_package_config_for_upgrade (which
was renamed to SetConfigFromRememberedArguments) method was borrowed,
as it was doing very similar work.  However, the code that was brought
over to Chocolatey GUI failed to realise that after splitting the
arguments on " --", when passed into the
arguments_contain_sensitive_information (which was renamed to
SensitiveArgumentsProvided) that a sensitive variable would no longer
be detected as this method expects that all arguments under test start
with a "-".


## Motivation and Context

Ensure that no sensitive persisted arguments are displayed through Chocolatey GUI.

## Testing

1. Enable the Chocolatey feature to use remembered arguments
1. Install a package using Chocolatey CLI where a sensitive argument is passed in, for example `choco install packageA --user=bob --password=bill"
2. Open Chocolatey GUI and open the details window for the package that you just installed
3. Click the "View Package Arguments" button
4. Ensure that the value of the password argument is not shown

### Operating Systems Testing

Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1000 