### PR TITLE
(#1005) Normalize version numbers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,3 +73,5 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+dotnet_diagnostic.RS0030.severity = error
+dotnet_diagnostic.RS0031.severity = error

--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Services\IPackageArgumentsService.cs" />
     <Compile Include="Services\PackageArgumentsService.cs" />
     <Compile Include="Utilities\Converters\LocalizationConverter.cs" />
+    <Compile Include="Utilities\Converters\NuGetVersionToString.cs" />
     <Compile Include="Utilities\Extensions\LocalizeExtension.cs" />
     <Compile Include="Utilities\Converters\NullToInverseBool.cs" />
     <Compile Include="Utilities\ToolTipBehavior.cs" />

--- a/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
+++ b/Source/ChocolateyGui.Common.Windows/ChocolateyGui.Common.Windows.csproj
@@ -422,8 +422,15 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/../" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\ChocolateyGui\BannedSymbols.txt">
+      <Link>BannedSymbols.txt</Link>
+    </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\HarfBuzzSharp.2.6.1.4\build\net462\HarfBuzzSharp.targets" Condition="Exists('..\packages\HarfBuzzSharp.2.6.1.4\build\net462\HarfBuzzSharp.targets')" />

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -195,7 +195,7 @@ namespace ChocolateyGui.Common.Windows.Services
 
                             if (version != null)
                             {
-                                config.Version = version.ToString();
+                                config.Version = version;
                             }
 
                             if (source != null)

--- a/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NuGetVersionToString.cs
+++ b/Source/ChocolateyGui.Common.Windows/Utilities/Converters/NuGetVersionToString.cs
@@ -1,0 +1,36 @@
+﻿namespace ChocolateyGui.Common.Windows.Utilities.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Windows;
+    using System.Windows.Data;
+    using chocolatey;
+    using NuGet.Versioning;
+
+    public class NuGetVersionToString : DependencyObject, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is NuGetVersion version)
+            {
+                return version.ToNormalizedStringChecked();
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string sValue && NuGetVersion.TryParse(sValue, out var version))
+            {
+                return version;
+            }
+
+            throw new InvalidOperationException("The passed in value is not a parseable string version!");
+        }
+    }
+}

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/AdvancedInstallViewModel.cs
@@ -66,7 +66,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
             _cts = new CancellationTokenSource();
 
-            _packageVersion = packageVersion.ToString();
+            _packageVersion = packageVersion.ToNormalizedStringChecked();
             SelectedVersion = _packageVersion;
 
             FetchAvailableVersions();

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using Caliburn.Micro;
+using chocolatey;
 using ChocolateyGui.Common.Base;
 using ChocolateyGui.Common.Models;
 using ChocolateyGui.Common.Models.Messages;
@@ -405,7 +406,8 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         public async Task ShowArguments()
         {
-            var decryptedArguments = _packageArgumentsService.DecryptPackageArgumentsFile(Id, Version.ToString()).ToList();
+            // TODO: Add legacy handling for packages installed prior to v2.0.0.
+            var decryptedArguments = _packageArgumentsService.DecryptPackageArgumentsFile(Id, Version.ToNormalizedStringChecked()).ToList();
 
             if (decryptedArguments.Count == 0)
             {
@@ -423,7 +425,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
 
         public async Task Install()
         {
-            await InstallPackage(Version.ToString());
+            await InstallPackage(Version.ToNormalizedStringChecked());
         }
 
         public async Task InstallAdvanced()
@@ -465,7 +467,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
                 {
                     using (await StartProgressDialog(L(nameof(Resources.PackageViewModel_ReinstallingPackage)), L(nameof(Resources.PackageViewModel_ReinstallingPackage)), Id))
                     {
-                        await _chocolateyService.InstallPackage(Id, Version.ToString(), Source, true);
+                        await _chocolateyService.InstallPackage(Id, Version.ToNormalizedStringChecked(), Source, true);
                         _chocolateyGuiCacheService.PurgeOutdatedPackages();
                         await _eventAggregator.PublishOnUIThreadAsync(new PackageChangedMessage(Id, PackageChangeType.Installed, Version));
                     }
@@ -496,7 +498,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
                 {
                     using (await StartProgressDialog(L(nameof(Resources.PackageViewModel_UninstallingPackage)), L(nameof(Resources.PackageViewModel_UninstallingPackage)), Id))
                     {
-                        var result = await _chocolateyService.UninstallPackage(Id, Version.ToString(), true);
+                        var result = await _chocolateyService.UninstallPackage(Id, Version.ToNormalizedStringChecked(), true);
 
                         if (!result.Successful)
                         {
@@ -584,7 +586,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             {
                 using (await StartProgressDialog(L(nameof(Resources.PackageViewModel_PinningPackage)), L(nameof(Resources.PackageViewModel_PinningPackage)), Id))
                 {
-                    var result = await _chocolateyService.PinPackage(Id, Version.ToString());
+                    var result = await _chocolateyService.PinPackage(Id, Version.ToNormalizedStringChecked());
 
                     if (!result.Successful)
                     {
@@ -628,7 +630,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             {
                 using (await StartProgressDialog(L(nameof(Resources.PackageViewModel_UnpinningPackage)), L(nameof(Resources.PackageViewModel_UnpinningPackage)), Id))
                 {
-                    var result = await _chocolateyService.UnpinPackage(Id, Version.ToString());
+                    var result = await _chocolateyService.UnpinPackage(Id, Version.ToNormalizedStringChecked());
 
                     if (!result.Successful)
                     {

--- a/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/LocalSourceView.xaml
@@ -14,12 +14,14 @@
              xmlns:commands="clr-namespace:ChocolateyGui.Common.Windows.Commands"
              xmlns:controls="clr-namespace:ChocolateyGui.Common.Windows.Controls"
              xmlns:theming="clr-namespace:ChocolateyGui.Common.Windows.Theming"
+             xmlns:converters="clr-namespace:ChocolateyGui.Common.Windows.Utilities.Converters"
              mc:Ignorable="d"
              d:DesignHeight="768" d:DesignWidth="1366"
-             d:DataContext="{d:DesignInstance viewModels:LocalSourceViewModel}"
+             d:DataContext="{d:DesignInstance {x:Type viewModels:LocalSourceViewModel}}"
              Background="{DynamicResource MahApps.Brushes.ThemeBackground}">
 
     <UserControl.Resources>
+        <converters:NuGetVersionToString x:Key="NuGetVersionToString"/>
         <utilities:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
         <utilities:PackageAuthorsComparer x:Key="PackageAuthorsComparer" />
 
@@ -59,12 +61,12 @@
                 <TextBlock Grid.Row="2"
                            Margin="4 0"
                            Style="{DynamicResource TileLatestVersionTextStyle}"
-                           Text="{Binding LatestVersion, Mode=OneWay}" />
+                           Text="{Binding LatestVersion, Converter={StaticResource NuGetVersionToString}, Mode=OneWay}" />
 
                 <TextBlock Grid.Row="3"
                            Margin="4 0 4 1"
                            Style="{DynamicResource TileVersionTextStyle}"
-                           Text="{Binding Version, Mode=OneWay}" />
+                           Text="{Binding Version, Converter={StaticResource NuGetVersionToString}, Mode=OneWay}" />
 
                 <ContentControl x:Name="OutOfDateOverlay" Grid.Row="0" Grid.RowSpan="4"
                                 Visibility="Collapsed"
@@ -320,7 +322,7 @@
                                                             <ColumnDefinition Width="*" />
                                                         </Grid.ColumnDefinitions>
                                                         <TextBlock Grid.Column="0"
-                                                                   Text="{Binding LatestVersion, IsAsync=True}"
+                                                                   Text="{Binding LatestVersion, Converter={StaticResource NuGetVersionToString}, IsAsync=True}"
                                                                    Padding="3 3 2 3"
                                                                    VerticalAlignment="Stretch"
                                                                    HorizontalAlignment="Left"

--- a/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/PackageView.xaml
@@ -24,6 +24,7 @@
     </FrameworkElement.CommandBindings>
 
     <UserControl.Resources>
+        <converters:NuGetVersionToString x:Key="NuGetVersionToString"/>
         <converters:NullToVisibility x:Key="UriToVisibility" />
         <converters:NullToVisibility x:Key="NullToVisibility" />
         <converters:LongSizeToFileSizeString x:Key="LongSizeToFileSizeString" />
@@ -196,7 +197,7 @@
             <Label Style="{StaticResource PackageResourceLabel}"
                    Content="{lang:Localize PackageView_Version}"
                    Target="{Binding ElementName=Version}" />
-            <TextBlock x:Name="Version" Text="{Binding Version}"
+            <TextBlock x:Name="Version" Text="{Binding Version, Converter={StaticResource NuGetVersionToString}}"
                        Style="{StaticResource PackageResourceValue}" />
             
             <Label Style="{StaticResource PackageResourceLabel}" Content="{lang:Localize PackageView_Downloads}"

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -12,6 +12,7 @@
              xmlns:commands="clr-namespace:ChocolateyGui.Common.Windows.Commands"
              xmlns:controls="clr-namespace:ChocolateyGui.Common.Windows.Controls"
              xmlns:theming="clr-namespace:ChocolateyGui.Common.Windows.Theming"
+             xmlns:converters="clr-namespace:ChocolateyGui.Common.Windows.Utilities.Converters"
              mc:Ignorable="d"
              d:DesignHeight="768" d:DesignWidth="1366"
              d:DataContext="{d:DesignInstance viewModels:RemoteSourceViewModel}"
@@ -19,6 +20,7 @@
 
     <UserControl.Resources>
         <ResourceDictionary>
+            <converters:NuGetVersionToString x:Key="NuGetVersionToString"/>
             <DataTemplate x:Key="PackageListTemplate" DataType="{x:Type items:IPackageViewModel}">
                 <Grid Height="115" Margin="5"
                       Background="Transparent"
@@ -43,7 +45,7 @@
                                 <TextBlock.Text>
                                     <MultiBinding StringFormat="{}{0} {1}">
                                         <Binding Path="Title" Mode="OneWay" />
-                                        <Binding Path="Version" Mode="OneWay" />
+                                        <Binding Path="Version" Mode="OneWay" Converter="{StaticResource NuGetVersionToString}" />
                                     </MultiBinding>
                                 </TextBlock.Text>
                             </TextBlock>
@@ -151,7 +153,7 @@
                                     <TextBlock.Text>
                                         <MultiBinding StringFormat="{}{0} {1}">
                                             <Binding Path="Title" Mode="OneWay" />
-                                            <Binding Path="Version" Mode="OneWay" />
+                                            <Binding Path="Version" Mode="OneWay" Converter="{StaticResource NuGetVersionToString}" />
                                         </MultiBinding>
                                     </TextBlock.Text>
                                 </TextBlock>
@@ -270,7 +272,7 @@
                     <TextBlock Grid.Row="2"
                                Margin="4 0 4 1"
                                Style="{DynamicResource TileVersionTextStyle}"
-                               Text="{Binding Version, Mode=OneWay}" />
+                               Text="{Binding Version, Converter={StaticResource NuGetVersionToString}, Mode=OneWay}" />
 
                     <ContentControl x:Name="IsInstalledOverlay" Grid.Row="0" Grid.RowSpan="3"
                                     Visibility="Collapsed"

--- a/Source/ChocolateyGui.Common.Windows/packages.config
+++ b/Source/ChocolateyGui.Common.Windows/packages.config
@@ -20,6 +20,7 @@
   <package id="MahApps.Metro.SimpleChildWindow" version="2.0.0" targetFramework="net48" />
   <package id="Markdig.Signed" version="0.23.0" targetFramework="net48" />
   <package id="Markdig.Wpf.Signed" version="0.5.0.1" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.4" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net452" />

--- a/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
+++ b/Source/ChocolateyGui.Common/ChocolateyGui.Common.csproj
@@ -226,12 +226,19 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/../" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
     <SourceRoot Include="$(MSBuildThisFileDirectory)/../" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Startup\Adapters\" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\ChocolateyGui\BannedSymbols.txt">
+      <Link>BannedSymbols.txt</Link>
+    </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/ChocolateyGui.Common/packages.config
+++ b/Source/ChocolateyGui.Common/packages.config
@@ -6,6 +6,7 @@
   <package id="chocolatey.lib" version="2.1.0-alpha-20230605-1278" targetFramework="net48" />
   <package id="LiteDB" version="5.0.15" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.4" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net452" />
   <package id="Serilog" version="2.5.0" targetFramework="net48" />

--- a/Source/ChocolateyGui/BannedSymbols.txt
+++ b/Source/ChocolateyGui/BannedSymbols.txt
@@ -1,0 +1,6 @@
+M:NuGet.Versioning.SemanticVersion.ToFullString;Use ToFullStringChecked() extension method instead.
+M:Chocolatey.NuGet.Versioning.SemanticVersion.ToFullString();Use ToFullStringChecked() extension method instead.
+M:NuGet.Versioning.SemanticVersion.ToNormalizedString;Use ToNormalizedStringChecked() extension method instead.
+M:Chocolatey.NuGet.Versioning.SemanticVersion.ToNormalizedString();Use ToNormalizedStringChecked() extension method instead.
+M:NuGet.Versioning.SemanticVersion.ToString;Use ToNormalizedStringChecked() extension method instead.
+M:Chocolatey.NuGet.Versioning.SemanticVersion.ToString();Use ToNormalizedStringChecked() extension method instead.

--- a/Source/ChocolateyGui/ChocolateyGui.csproj
+++ b/Source/ChocolateyGui/ChocolateyGui.csproj
@@ -320,6 +320,7 @@
       <SubType>Designer</SubType>
     </None>
     <Resource Include="chocolatey%405.png" />
+    <AdditionalFiles Include="BannedSymbols.txt" />
     <Content Include="ChocolateyGui.exe.manifest">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -343,6 +344,8 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>

--- a/Source/ChocolateyGui/packages.config
+++ b/Source/ChocolateyGui/packages.config
@@ -20,6 +20,7 @@
   <package id="MahApps.Metro.SimpleChildWindow" version="2.0.0" targetFramework="net48" />
   <package id="Markdig.Signed" version="0.23.0" targetFramework="net48" />
   <package id="Markdig.Wpf.Signed" version="0.5.0.1" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.4" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net452" />

--- a/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
+++ b/Source/ChocolateyGuiCli/ChocolateyGuiCli.csproj
@@ -130,8 +130,15 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/../" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\ChocolateyGui\BannedSymbols.txt">
+      <Link>BannedSymbols.txt</Link>
+    </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/ChocolateyGuiCli/packages.config
+++ b/Source/ChocolateyGuiCli/packages.config
@@ -5,6 +5,7 @@
   <package id="chocolatey.lib" version="2.1.0-alpha-20230605-1278" targetFramework="net48" />
   <package id="LiteDB" version="5.0.15" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.4" targetFramework="net48" developmentDependency="true" />
   <package id="Serilog" version="2.5.0" targetFramework="net48" />
   <package id="Serilog.Sinks.Async" version="1.1.0" targetFramework="net48" />
   <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

This pull request normalizes the dispaying and usages of normalized version numbers.
To aid and try prevent non-normalized version numbers used, a banned API analyzer has also been added.

## Motivation and Context

We should use the equivalent of version normalization that was introduced in Chocolatey CLI v2.0.0.

## Testing

1. Open Chocolatey GUI
2. Navigate to the Chocolatey Source
3. Search for 7zip.portable
4. Verify 7zip.portable is shown with normalized version (ie 3 part version without leading zeros).
5. Open detail page.
6. Verify again only normalized version numbers are shown.
7. Click button for advanced installation.
8. Verify drop down list shows normalized version number of latest version.
9. Install the package.
10. Navigate to `This PC`.
11. Verify installed 7zip.portable package is shown with normalized version number.
12. Open details page and verify again normalized version number is shown.
13. View Package Arguments (**NOTE: Manual work may be needed if running in debug mode**).
14. Verify the package arguments are shown

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1005