### PR TITLE
(#1003) Handle null keys during source translation

### DIFF
--- a/Source/ChocolateyGui.Common/Utilities/TranslationSource.cs
+++ b/Source/ChocolateyGui.Common/Utilities/TranslationSource.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright company="Chocolatey" file="TranslationSource.cs">
 //   Copyright 2017 - Present Chocolatey Software, LLC
 //   Copyright 2014 - 2017 Rob Reynolds, the maintainers of Chocolatey, and RealDimensions Software, LLC
@@ -47,6 +47,14 @@ namespace ChocolateyGui.Common.Utilities
         {
             get
             {
+                if (string.IsNullOrEmpty(key))
+                {
+                    // If the key is null we can't pass it to the resource manager.
+                    // As it also doesn't make sense to pass in an empty value we check for both.
+                    // We pass this empty string as we don't want anything to break even on empty values.
+                    return string.Empty;
+                }
+
                 var value = _resourceManager.GetString(key, CurrentCulture);
 #if DEBUG
                 if (string.IsNullOrEmpty(value) && !string.IsNullOrEmpty(key))


### PR DESCRIPTION
## Description Of Changes

The helper class that is used whe looking up any translations that has
been made did not handle the translation source strings when they
are null or empty. This causes problems when especially looking up
description of Chocolatey settings items that by some reason did
not have a description associated with themself in the configuration
file.

## Motivation and Context

We should not throw any exceptions when looking up translations that could abort the entire execution of Chocolatey GUI.

## Testing

Build a release version of Chocolatey GUI and run the following on a completely new system.

1. Install Chocolatey v2.0.0 using normal installation on https://chocolatey.org/install
2. Run `choco install chocolateygui --pre --source "<LOCATION_OF_BUILT_BINARY>;chocolatey"
3. Open Chocolatey GUI as an administrator.
4. Navigate to the settings page.
5. Ensure an exception is not thrown, and will show Chocolatey settings that are missing a description.

### Operating Systems Testing

- Windows Server 2022
- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #1003

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
