### PR TITLE
(#993) (fix) Correct syntax in KTS file, duplicate scriptContent assignment

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -61,7 +61,7 @@ object ChocolateyGUI : BuildType({
 
         script {
             name = "Call Cake"
-            scriptContent = scriptContent = """
+            scriptContent = """
                 IF "%teamcity.build.triggeredBy%" == "Schedule Trigger" (SET TestType=all) ELSE (SET TestType=unit)
                 call build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=%%TestType%% --shouldRunOpenCover=false
             """.trimIndent()

--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="./build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' %*"
-
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%

--- a/build.debug.bat
+++ b/build.debug.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="./build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' -Configuration Debug %*"
-
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%

--- a/build.official.bat
+++ b/build.official.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="./build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' -Configuration ReleaseOfficial -Target CI %*"
-
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' -Configuration ReleaseOfficial %*"
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%


### PR DESCRIPTION
## Description Of Changes

This PR removes the duplicate assignment of scriptContent in the Call Cake script step.

## Motivation and Context

The syntax was incorrect and prevented the KTS file from being imported.

## Testing

I compared this file pre and post edit to the other KTS files that are importing, was also guided by the error messages from the failed import.

### Operating Systems Testing

N/A

## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to #993
