### PR TITLE
 (ENGTASKS-3098) Create TC build for Unit, Integration, and QA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
 
       - name: Build project
+        shell: powershell
         run: |
           ./build.ps1 --target=CI
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,16 +3,19 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.ScheduleTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 
 project {
     buildType(ChocolateyGUI)
+    buildType(ChocolateyGUISchd)
+    buildType(ChocolateyGUIQA)
 }
 
 object ChocolateyGUI : BuildType({
     id = AbsoluteId("ChocolateyGUI")
-    name = "Build"
+    name = "Chocolatey GUI (Built with Unit Tests)"
 
     artifactRules = """
         code_drop/MsBuild.log
@@ -62,8 +65,7 @@ object ChocolateyGUI : BuildType({
         script {
             name = "Call Cake"
             scriptContent = """
-                IF "%teamcity.build.triggeredBy%" == "Schedule Trigger" (SET TestType=all) ELSE (SET TestType=unit)
-                call build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=%%TestType%% --shouldRunOpenCover=false
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
             """.trimIndent()
         }
     }
@@ -71,17 +73,6 @@ object ChocolateyGUI : BuildType({
     triggers {
         vcs {
             branchFilter = ""
-        }
-        schedule {
-            schedulingPolicy = daily {
-                hour = 2
-                minute = 0
-            }
-            branchFilter = """
-                +:<default>
-            """.trimIndent()
-            triggerBuild = always()
-			withPendingChangesOnly = false
         }
     }
 
@@ -92,6 +83,147 @@ object ChocolateyGUI : BuildType({
                     token = "%system.GitHubPAT%"
                 }
             }
+        }
+    }
+})
+
+object ChocolateyGUISchd : BuildType({
+    id = AbsoluteId("ChocolateyGUISchd")
+    name = "Chocolatey GUI (Scheduled Integration Testing)"
+
+    artifactRules = """
+        code_drop/MsBuild.log
+        code_drop/MSBuild.msi.log
+        code_drop/ChocolateyGUI.msi
+        code_drop/TestResults/issues-report.html
+        code_drop/Packages/**/*.nupkg
+    """.trimIndent()
+
+    params {
+        param("env.vcsroot.branch", "%vcsroot.branch%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.ChocolateyGUI_ChocolateyGuiVcsRoot%")
+        param("teamcity.git.fetchAllHeads", "true")
+        password("env.TRANSIFEX_API_TOKEN", "credentialsJSON:c81283e6-cf59-5c9e-9766-6f465018a295", display = ParameterDisplay.HIDDEN, readOnly = true)
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+
+        branchFilter = """
+            +:*
+        """.trimIndent()
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    # Install Chocolatey Requirements
+                    if ((Get-WindowsFeature -Name NET-Framework-Features).InstallState -ne 'Installed') {
+                        Install-WindowsFeature -Name NET-Framework-Features
+                    }
+
+                    choco install windows-sdk-7.1 netfx-4.0.3-devpack visualstudio2019buildtools netfx-4.8-devpack --confirm --no-progress
+                    exit ${'$'}LastExitCode
+                """.trimIndent()
+            }
+        }
+
+        step {
+            name = "Include Signing Keys"
+            type = "PrepareSigningEnvironment"
+        }
+
+        script {
+            name = "Call Cake"
+            scriptContent = """
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=all --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false
+            """.trimIndent()
+        }
+    }
+
+    triggers {
+        schedule {
+            schedulingPolicy = daily {
+                hour = 2
+                minute = 0
+            }
+            branchFilter = """
+                +:<default>
+            """.trimIndent()
+            triggerBuild = always()
+            withPendingChangesOnly = false
+        }
+    }
+})
+
+object ChocolateyGUIQA : BuildType({
+    id = AbsoluteId("ChocolateyGUIQA")
+    name = "Chocolatey GUI (SonarQube)"
+
+    artifactRules = """
+    """.trimIndent()
+
+    params {
+        param("env.vcsroot.branch", "%vcsroot.branch%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.ChocolateyGUI_ChocolateyGuiVcsRoot%")
+        param("env.SONARQUBE_ID", "chocolateygui")
+        param("teamcity.git.fetchAllHeads", "true")
+        password("env.TRANSIFEX_API_TOKEN", "credentialsJSON:c81283e6-cf59-5c9e-9766-6f465018a295", display = ParameterDisplay.HIDDEN, readOnly = true)
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+
+        branchFilter = """
+            +:*
+        """.trimIndent()
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    # Install Chocolatey Requirements
+                    if ((Get-WindowsFeature -Name NET-Framework-Features).InstallState -ne 'Installed') {
+                        Install-WindowsFeature -Name NET-Framework-Features
+                    }
+
+                    choco install windows-sdk-7.1 netfx-4.0.3-devpack visualstudio2019buildtools netfx-4.8-devpack --confirm --no-progress
+                    exit ${'$'}LastExitCode
+                """.trimIndent()
+            }
+        }
+
+        step {
+            name = "Include Signing Keys"
+            type = "PrepareSigningEnvironment"
+        }
+
+        script {
+            name = "Call Cake"
+            scriptContent = """
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldRunSonarQube=true --shouldRunDependencyCheck=true
+            """.trimIndent()
+        }
+    }
+
+    triggers {
+        schedule {
+            schedulingPolicy = weekly {
+                dayOfWeek = ScheduleTrigger.DAY.Saturday
+                hour = 2
+                minute = 45
+            }
+            branchFilter = """
+                +:<default>
+            """.trimIndent()
+            triggerBuild = always()
+            withPendingChangesOnly = false
         }
     }
 })

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.25.0
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.26.3
 
 ///////////////////////////////////////////////////////////////////////////////
 // MODULES
@@ -13,7 +13,7 @@
 if (BuildSystem.IsLocalBuild)
 {
     Environment.SetVariableNames(
-        gitHubTokenVariable: "CHOCOLATEYGUI_GITHUB_PAT",
+        gitReleaseManagerTokenVariable: "CHOCOLATEYGUI_GITHUB_PAT",
         transifexApiTokenVariable: "CHOCOLATEYGUI_TRANSIFEX_API_TOKEN"
     );
 }


### PR DESCRIPTION
## Description Of Changes

This PR splits the current general TeamCity build which runs unit tests on a version control trigger and unit + integration tests on a schedule into two separate builds:

* Chocolatey GUI (Built with Unit Tests) `ID: ChocolateyGUI`
* Chocolatey GUI (Scheduled Integration Testing) `ID: ChocolateyGUISchd `

It also introduces an additional build specifically for running Code Analysis and Dependency Checking:

* Chocolatey GUI (SonarQube) `ID: ChocolateyGUIQA`

Note: Please advise if these names are appropriate and recommend alternatives as needed.

## Motivation and Context

This change enables TeamCity to accurately track how long each build configuration should take to run and how many tests each should run.

## Testing

This has been tested on a non-Production TeamCity instance, the KTS file imported successfully and the three builds ran as expected.

![image](https://github.com/chocolatey/ChocolateyGUI/assets/6955786/4b8c362b-15ee-46f8-8bfa-907ab2a5b60a)

### Operating Systems Testing

N/A

## Change Types Made

N/A? Build change

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
