### PR TITLE
(#996) Create config directory if it doesn't exist

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
+++ b/Source/ChocolateyGui.Common.Windows/Startup/ChocolateyGuiModule.cs
@@ -148,13 +148,22 @@ namespace ChocolateyGui.Common.Windows.Startup
                 var userDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.LocalAppDataPath, "data.db")};upgrade=true");
 
                 LiteDatabase globalDatabase;
+                var globalConfigDirectory = Path.Combine(Bootstrapper.AppDataPath, "Config");
+                var globalConfigDatabaseFile = Path.Combine(globalConfigDirectory, "data.db");
+
                 if (Hacks.IsElevated)
                 {
-                    globalDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")};upgrade=true");
+                    if (!Directory.Exists(globalConfigDirectory))
+                    {
+                        Directory.CreateDirectory(globalConfigDirectory);
+                        Hacks.LockDirectory(globalConfigDirectory);
+                    }
+
+                    globalDatabase = new LiteDatabase($"filename={globalConfigDatabaseFile};upgrade=true");
                 }
                 else
                 {
-                    if (!File.Exists(Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")))
+                    if (!File.Exists(globalConfigDatabaseFile))
                     {
                         // Since the global configuration database file doesn't exist, we must be running in a state where an administrator user
                         // has never run Chocolatey GUI. In this case, use null, which will mean attempts to use the global database will be ignored.
@@ -163,7 +172,7 @@ namespace ChocolateyGui.Common.Windows.Startup
                     else
                     {
                         // Since this is a non-administrator user, they should only have read permissions to this database
-                        globalDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")};readonly=true");
+                        globalDatabase = new LiteDatabase($"filename={globalConfigDatabaseFile};readonly=true");
                     }
                 }
 

--- a/Source/ChocolateyGui.Common/Hacks.cs
+++ b/Source/ChocolateyGui.Common/Hacks.cs
@@ -5,6 +5,9 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.IO;
+using System.Security.AccessControl;
 using System.Security.Principal;
 
 namespace ChocolateyGui.Common
@@ -12,5 +15,33 @@ namespace ChocolateyGui.Common
     public static class Hacks
     {
         public static bool IsElevated => (WindowsIdentity.GetCurrent().Owner?.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid)).GetValueOrDefault(false);
+
+        // TODO: Replace this LockDirectory with calls to DotNetFileSystem's LockDirectory when https://github.com/chocolatey/ChocolateyGUI/issues/1046 is completed.
+        /// <summary>
+        /// Lock the given directory path to just Administrators being able to write. This method is copied from chocolatey.infrastructure.filesystem.DotNetFileSystem, and should be replaced with that call when the minimum Chocolatey.lib is bumped to 2.2.0 or greater.
+        /// </summary>
+        /// <param name="directoryPath">Directory path to lock down.</param>
+        public static void LockDirectory(string directoryPath)
+        {
+            var permissions = Directory.GetAccessControl(directoryPath);
+            var rules = permissions.GetAccessRules(includeExplicit: true, includeInherited: true, targetType: typeof(NTAccount));
+
+            // We first need to remove all rules
+            foreach (FileSystemAccessRule rule in rules)
+            {
+                permissions.RemoveAccessRuleAll(rule);
+            }
+
+            var bultinAdmins = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount));
+            var localsystem = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Translate(typeof(NTAccount));
+            var builtinUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null).Translate(typeof(NTAccount));
+            var inheritanceFlags = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+            permissions.SetAccessRule(new FileSystemAccessRule(bultinAdmins, FileSystemRights.FullControl, inheritanceFlags, PropagationFlags.None, AccessControlType.Allow));
+            permissions.SetAccessRule(new FileSystemAccessRule(localsystem, FileSystemRights.FullControl, inheritanceFlags, PropagationFlags.None, AccessControlType.Allow));
+            permissions.SetAccessRule(new FileSystemAccessRule(builtinUsers, FileSystemRights.ReadAndExecute, inheritanceFlags, PropagationFlags.None, AccessControlType.Allow));
+            permissions.SetOwner(bultinAdmins);
+            permissions.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+            Directory.SetAccessControl(directoryPath, permissions);
+        }
     }
 }

--- a/Source/ChocolateyGuiCli/Startup/ChocolateyGuiCliModule.cs
+++ b/Source/ChocolateyGuiCli/Startup/ChocolateyGuiCliModule.cs
@@ -48,13 +48,22 @@ namespace ChocolateyGuiCli.Startup
                 var userDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.LocalAppDataPath, "data.db")};upgrade=true");
 
                 LiteDatabase globalDatabase;
+                var globalConfigDirectory = Path.Combine(Bootstrapper.AppDataPath, "Config");
+                var globalConfigDatabaseFile = Path.Combine(globalConfigDirectory, "data.db");
+
                 if (Hacks.IsElevated)
                 {
-                    globalDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")};upgrade=true");
+                    if (!Directory.Exists(globalConfigDirectory))
+                    {
+                        Directory.CreateDirectory(globalConfigDirectory);
+                        Hacks.LockDirectory(globalConfigDirectory);
+                    }
+                    
+                    globalDatabase = new LiteDatabase($"filename={globalConfigDatabaseFile};upgrade=true");
                 }
                 else
                 {
-                    if (!File.Exists(Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")))
+                    if (!File.Exists(globalConfigDatabaseFile))
                     {
                         // Since the global configuration database file doesn't exist, we must be running in a state where an administrator user
                         // has never run Chocolatey GUI. In this case, use null, which will mean attempts to use the global database will be ignored.
@@ -63,7 +72,7 @@ namespace ChocolateyGuiCli.Startup
                     else
                     {
                         // Since this is a non-administrator user, they should only have read permissions to this database
-                        globalDatabase = new LiteDatabase($"filename={Path.Combine(Bootstrapper.AppDataPath, "Config", "data.db")};readonly=true");
+                        globalDatabase = new LiteDatabase($"filename={globalConfigDatabaseFile};readonly=true");
                     }
                 }
 


### PR DESCRIPTION
## Description Of Changes

Create the `C:\ProgramData\Chocolatey GUI\Config\` directory if it doesn't already exist.

## Motivation and Context

LiteDatabase doesn't handle creating the directory if it's not there. And cannot create it's file if the parent directory doesn't exist.

## Testing

1. Delete `C:\ProgramData\Chocolatey Gui\` directory.
2. Launch Chocolatey GUI.
3. Ensure it doesn't error.
4. Delete `C:\ProgramData\Chocolatey Gui\` directory.
5. Run `chocolateyguicli -?`.
6. Ensure Help is output by Chocolatey GUI CLI.

### Operating Systems Testing

- Windows 10
- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added. - Added to internal manual testing document.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #996