### PR TITLE
(build) Add templated notifications to all build configurations

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -18,6 +18,8 @@ object ChocolateyGUI : BuildType({
     id = AbsoluteId("ChocolateyGUI")
     name = "Chocolatey GUI (Built with Unit Tests)"
 
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
     artifactRules = """
     """.trimIndent()
 
@@ -87,6 +89,8 @@ object ChocolateyGUISchd : BuildType({
     id = AbsoluteId("ChocolateyGUISchd")
     name = "Chocolatey GUI (Scheduled Integration Testing)"
 
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
     artifactRules = """
     """.trimIndent()
 
@@ -148,6 +152,8 @@ object ChocolateyGUISchd : BuildType({
 object ChocolateyGUIQA : BuildType({
     id = AbsoluteId("ChocolateyGUIQA")
     name = "Chocolatey GUI (SonarQube)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     artifactRules = """
     """.trimIndent()
@@ -212,6 +218,8 @@ object ChocolateyGUIQA : BuildType({
 object ChocolateyGUISign : BuildType({
     id = AbsoluteId("ChocolateyGUISign")
     name = "Chocolatey GUI (Script Signing)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     artifactRules = """
     """.trimIndent()


### PR DESCRIPTION
## Description Of Changes

This PR makes each build configuration in the TeamCity KTS file reference a template containing standard Slack notification configuration, which applies said configuration to the build configuration without having to duplicate it in each.

## Motivation and Context

Enables standard notification configuration across all build configurations in this project.

## Testing

This change was initially tested by pointing a development TeamCity instance at the equivalent changes on the `chocolatey/choco` project. These notification changes are now live for that project and have been operating in production for some time.

### Operating Systems Testing

N/A

## Change Types Made

Build configuration change (non-breaking)

~~* [ ] Bug fix (non-breaking change).~~
~~* [ ] Feature / Enhancement (non-breaking change).~~
~~* [ ] Breaking change (fix or feature that could cause existing functionality to change).~~
~~* [ ] Documentation changes.~~
~~* [ ] PowerShell code changes.~~

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A