### PR TITLE
(#1120) Fix gathering of files for signing

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -32,12 +32,19 @@ Func<FilePathCollection> getScriptsToVerify = () =>
         Information(scriptToVerify.FullPath);
     }
 
+    var numberOfScriptsToVerify = scriptsToVerify.Count();
+
+    if (numberOfScriptsToVerify != 3)
+    {
+        throw new Exception(string.Format("Expected to find 3 scripts to verify, but found {0}", numberOfScriptsToVerify));
+    }
+
     return scriptsToVerify;
 };
 
 Func<FilePathCollection> getScriptsToSign = () =>
 {
-    var scriptsToSign = GetFiles("./nuspec/**/*.{ps1|psm1|psd1}");
+    var scriptsToSign = GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/**/*.{ps1|psm1|psd1}");
 
     Information("The following PowerShell scripts have been selected to be signed...");
     foreach (var scriptToSign in scriptsToSign)
@@ -45,13 +52,20 @@ Func<FilePathCollection> getScriptsToSign = () =>
         Information(scriptToSign.FullPath);
     }
 
+    var numberOfScriptsToSign = scriptsToSign.Count();
+
+    if (numberOfScriptsToSign != 3)
+    {
+        throw new Exception(string.Format("Expected to find 3 scripts to verify, but found {0}", numberOfScriptsToSign));
+    }
+
     return scriptsToSign;
 };
 
 Func<FilePathCollection> getFilesToSign = () =>
 {
-    var filesToSign = GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/^{ChocolateyGui|ChocolateyGuiCli}/{ChocolateyGui|ChocolateyGuiCli}*.{exe|dll}") +
-                    GetFiles(BuildParameters.Paths.Directories.PublishedLibraries + "/ChocolateyGui*/ChocolateyGui*.dll");
+    var filesToSign = GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/^{ChocolateyGui|ChocolateyGuiCli}/net48/{ChocolateyGui|ChocolateyGuiCli}*.{exe|dll}") +
+                    GetFiles(BuildParameters.Paths.Directories.PublishedLibraries + "/ChocolateyGui*/net48/ChocolateyGui*.dll");
 
     var platformTarget = ToolSettings.BuildPlatformTarget == PlatformTarget.MSIL ? "AnyCPU" : ToolSettings.BuildPlatformTarget.ToString();
     foreach(var project in ParseSolution(BuildParameters.SolutionFilePath).GetProjects())
@@ -88,6 +102,13 @@ Func<FilePathCollection> getFilesToSign = () =>
         Information(fileToSign.FullPath);
     }
 
+    var numberOfFilesToSign = filesToSign.Count();
+
+    if (numberOfFilesToSign != 13)
+    {
+        throw new Exception(string.Format("Expected to find 13 files to sign, but found {0}", numberOfFilesToSign));
+    }
+
     return filesToSign;
 };
 
@@ -99,6 +120,13 @@ Func<FilePathCollection> getMsisToSign = () =>
     foreach (var msiToSign in msisToSign)
     {
         Information(msiToSign.FullPath);
+    }
+
+    var numberOfMsisToSign = msisToSign.Count();
+
+    if (numberOfMsisToSign != 1)
+    {
+        throw new Exception(string.Format("Expected to find 1 msis to sign, but found {0}", numberOfMsisToSign));
     }
 
     return msisToSign;


### PR DESCRIPTION
## Description Of Changes

There are a number of files added to the net48 folder that _need_ to be signed, but these are not being picked up since the globbing pattern doesn't look in this folder.

This commit updates the globbing pattern to include this folder, and also adds an assertion about the number of files that are expected to be found from each glob.  This should prevent this from happening again, since the updating of the asserted version number should _only_ be done, when the number of expected files has been known to change.

## Motivation and Context

With the introduction of dotnet build, rather than msbuild, the new net48 folder is causing an issue with gathering of files that need to be signed using the Chocolatey authenticode certificate.

## Testing

@corbob has updated the Test-Kitchen tests to correctly identify all files that need to be checked.

Once this PR is merged, we should run the Test-Kitchen test, which is currently failing and ensure that it passes correctly

### Operating Systems Testing

Dev VM 4

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #1120