### PR TITLE
(maint) Support both packages.config and csproj

### DIFF
--- a/Get-ChocoUpdatedDebugVersion.ps1
+++ b/Get-ChocoUpdatedDebugVersion.ps1
@@ -66,9 +66,23 @@ function CheckoutTag {
 
 Write-Host "We are at $PSScriptRoot"
 
-[xml]$packagesConfigFile = Get-Content -Path "$PSScriptRoot/Source/ChocolateyGui/packages.config"
+$isNewCsproj = $false
+$packageConfigPath = "$PSScriptRoot/Source/ChocolateyGui/packages.config"
+$packageProjectPath = "$PSScriptRoot/Source/ChocolateyGui.Common/Chocolateygui.Common.csproj"
 
-$chocolateyLibPackageVersion = $($packagesConfigFile.packages.package | Where-Object { $_.id -eq "chocolatey.lib" }).version
+if (Test-Path $packageConfigPath) {
+    [xml]$packagesConfigFile = Get-Content -Path $packageConfigPath
+    $chocolateyLibPackageVersion = $($packagesConfigFile.packages.package | Where-Object { $_.id -eq "chocolatey.lib" }).version
+}
+elseif (Test-Path $packageProjectPath) {
+    [xml]$packagesProjectFile = Get-Content -Path $packageProjectPath
+    $chocolateyLibPackageVersion = $($packagesProjectFile.Project.ItemGroup.PackageReference | Where-Object { $_.Include -eq "chocolatey.lib" }).Version
+    $isNewCsproj = $true
+}
+else
+{
+    throw "No Packages.config or C# Project Files found. Unable to continue..."
+}
 
 if ($CheckoutRefTag) {
 
@@ -117,8 +131,8 @@ if (-not (Test-Path -Path $ChocoSourceLocation)) {
     throw "Location '$ChocoSourceLocation' not found; please rerun with the -ChocoSourceLocation parameter or set the CHOCO_SOURCE_LOCATION environment variable."
 }
 
-Write-Host "Restore packages on project first..."
-& ./build.debug.bat --target='Restore'
+Write-Host "Initializes project first..."
+& ./build.debug.bat --target='Init'
 
 Write-Host "Building choco at $ChocoSourceLocation with Debug..."
 
@@ -133,7 +147,12 @@ Pop-Location
 
 Write-Host "Copying chocolatey artifacts to current Chocolatey Package Version folder..."
 
-$chocolateyLibPackageFolder = "$PSScriptRoot/Source/packages/chocolatey.lib.$chocolateyLibPackageVersion/lib/net48"
+$chocolateyLibPackageFolder = if ($isNewCsproj) {
+    "$PSScriptRoot/Source/packages/chocolatey.lib/$chocolateyLibPackageVersion/lib/net48"
+}
+else {
+    "$PSScriptRoot/Source/packages/chocolatey.lib.$chocolateyLibPackageVersion/lib/net48"
+}
 
 if (-not (Test-Path -Path $chocolateyLibPackageFolder)) {
     New-Item -ItemType Directory -Path $chocolateyLibPackageFolder > $null
@@ -141,7 +160,10 @@ if (-not (Test-Path -Path $chocolateyLibPackageFolder)) {
 
 $codeDropLibs = "$ChocoSourceLocation/code_drop/temp/_PublishedLibs/chocolatey_merged"
 
-if (!(Test-Path $codeDropLibs)) {
+if (Test-Path "$codeDropLibs/net48") {
+    $codeDropLibs = "$codeDropLibs/net48"
+}
+elseif (!(Test-Path $codeDropLibs)) {
   $codeDropLibs = "$ChocoSourceLocation/code_drop/chocolatey/lib"
 }
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -157,6 +157,8 @@ BuildParameters.SetParameters(context: Context,
 
 ToolSettings.SetToolSettings(context: Context);
 
+BuildParameters.Tasks.InitTask.IsDependentOn("Strong-Name-Signer");
+
 BuildParameters.PrintParameters(Context);
 
 Build.RunDotNet();


### PR DESCRIPTION
## Description Of Changes

- Add conditional logic to detect and parse either `packages.config` or `.csproj` files for chocolatey.lib version
- Store detection result in `isNewCsproj` flag for downstream path logic
- Update `chocolateyLibPackageFolder` path construction based on project format
- Change build.debug.bat target from `Restore` to `Init`
- Add fallback logic for code_drop library path with net48 subdirectory support
- Throw descriptive error if neither package format is found

## Motivation and Context

Support modern SDK-style csproj projects alongside legacy packages.config format. Ensure script works with both old and new project structures and improve build initialization process.

## Testing

1. Run `.\Get-ChocoUpdatedDebugVersion.ps1 -CheckoutRefTag`
2. Wait for the build no finish.
3. Open the solution script, and debug the application (may need to run `Rebuild` first).
4. Verify the file `Source/packages/chocolatey.lib/2.7.0/lib/net48/chocolatey.dll` have the last changed date of today.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Feature / Enhancement (non-breaking change).
* [x] PowerShell code changes.

## Change Checklist

- [x] PowerShell code changes: PowerShell v3 compatibility checked? (_Not a package, not relevant for build scripts_)
- [x] All items are are completed on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

- Related to Task: https://app.clickup.com/t/20540031/PROJ-2817