### PR TITLE
(maint) Fix typos in resource strings

### DIFF
--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -767,7 +767,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There as an error attempting to read the contents of the .arguments file for version {0} of package &apos;{1}&apos;.  See log file for more information..
+        ///   Looks up a localized string similar to There was an error attempting to read the contents of the .arguments file for version {0} of package &apos;{1}&apos;.  See log file for more information..
         /// </summary>
         public static string Application_PackageArgumentsError {
             get {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -421,7 +421,7 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
   <data name="RemoteSourceViewModel_FailedToLoadRemotePackages" xml:space="preserve">
     <value>Failed to load remote packages!
 {0}</value>
-    <comment>{0} = The exception message that occured</comment>
+    <comment>{0} = The exception message that occurred</comment>
   </data>
   <data name="RemoteSourceViewModel_FeedSearchError" xml:space="preserve">
     <value>Feed Search Error</value>
@@ -1329,8 +1329,10 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Use Delayed Search</value>
   </data>
   <data name="Application_PackageArgumentsError" xml:space="preserve">
-    <value>There as an error attempting to read the contents of the .arguments file for version {0} of package '{1}'.  See log file for more information.</value>
-    <comment>{0} = The version of the selected package  {1} = The id for the currently selected package</comment>
+    <value>There was an error attempting to read the contents of the .arguments file for version {0} of package '{1}'.  See log file for more information.</value>
+    <comment>{0} = The version of the selected package
+{1} = The id for the currently selected package
+</comment>
   </data>
   <data name="PackageView_ButtonPackageArguments" xml:space="preserve">
     <value>View Package Arguments</value>


### PR DESCRIPTION
## Description Of Changes

* Fix "occured" to "occurred" in RemoteSourceViewModel_FailedToLoadRemotePackages comment
* Fix "There as an error" to "There was an error" in Application_PackageArgumentsError message
* Reformat Application_PackageArgumentsError comment for better readability
* Update corresponding Designer.cs file to reflect corrected error message

## Motivation and Context

Improve spelling accuracy in user-facing messages and enhance code quality and maintainability.

## Testing

N/A: Maintenance change with no functional impact. This was just found during translation.

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Documentation changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A