### PR TITLE
(#937) Replace Update terminology with Upgrade

### DIFF
--- a/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
+++ b/Source/ChocolateyGui.Common/Properties/Resources.Designer.cs
@@ -749,7 +749,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update the currently installed package version.
+        ///   Looks up a localized string similar to Upgrade the currently installed package version.
         /// </summary>
         public static string Application_OperationUpgrade {
             get {
@@ -965,7 +965,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prevent Usage of Update All Button.
+        ///   Looks up a localized string similar to Prevent Usage of Upgrade All Button.
         /// </summary>
         public static string ChocolateyGUI_PreventUsageOfUpdateAllButtonTitle {
             get {
@@ -1114,7 +1114,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update package &quot;{0}&quot;.
+        ///   Looks up a localized string similar to Failed to upgrade package &quot;{0}&quot;.
         ///Error: {1}{2}.
         /// </summary>
         public static string ChocolateyRemotePackageService_UpdateFailedMessage {
@@ -1124,7 +1124,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update package..
+        ///   Looks up a localized string similar to Failed to upgrade package..
         /// </summary>
         public static string ChocolateyRemotePackageService_UpdateFailedTitle {
             get {
@@ -1461,7 +1461,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pin (Ignore Updates).
+        ///   Looks up a localized string similar to Pin (Ignore Upgrades).
         /// </summary>
         public static string Controls_PackagesContextMenuPin {
             get {
@@ -1497,7 +1497,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update.
+        ///   Looks up a localized string similar to Upgrade.
         /// </summary>
         public static string Controls_PackagesContextMenuUpdate {
             get {
@@ -1848,7 +1848,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update All.
+        ///   Looks up a localized string similar to Upgrade All.
         /// </summary>
         public static string LocalSourceView_ButtonUpdateAll {
             get {
@@ -1857,7 +1857,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No packages need to be updated.
+        ///   Looks up a localized string similar to No packages need to be upgraded.
         /// </summary>
         public static string LocalSourceView_ButtonUpdateAllDisabled {
             get {
@@ -1875,7 +1875,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show Only Packages with Updates.
+        ///   Looks up a localized string similar to Show Only Packages with Upgrades.
         /// </summary>
         public static string LocalSourceView_CheckboxPkgsWithUpdates {
             get {
@@ -2010,7 +2010,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There&apos;s an update available for Chocolatey..
+        ///   Looks up a localized string similar to There&apos;s an upgrade available for Chocolatey..
         /// </summary>
         public static string LocalSourceViewModel_UpdateAvailableForChocolatey {
             get {
@@ -2100,7 +2100,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pin (Ignore Updates).
+        ///   Looks up a localized string similar to Pin (Ignore Upgrades).
         /// </summary>
         public static string PackageView_ButtonPin {
             get {
@@ -2136,7 +2136,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update.
+        ///   Looks up a localized string similar to Upgrade.
         /// </summary>
         public static string PackageView_ButtonUpdate {
             get {
@@ -2370,7 +2370,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to Update.
+        ///   Looks up a localized string similar to Failed to Upgrade.
         /// </summary>
         public static string PackageViewModel_FailedToUpdate {
             get {
@@ -3386,7 +3386,7 @@ namespace ChocolateyGui.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prevents the ability for user to use the Update All button. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed..
+        ///   Looks up a localized string similar to Prevents the ability for user to use the Upgrade All button. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed..
         /// </summary>
         public static string SettingsView_TogglePreventUsageOfUpdateAllButtonDescription {
             get {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -179,14 +179,14 @@ Error {2}{3}</value>
     <value>Failed to unpin package.</value>
   </data>
   <data name="ChocolateyRemotePackageService_UpdateFailedMessage" xml:space="preserve">
-    <value>Failed to update package "{0}".
+    <value>Failed to upgrade package "{0}".
 Error: {1}{2}</value>
-    <comment>{0} = The name of the package that failed to update
+    <comment>{0} = The name of the package that failed to upgrade
 {1} = A collection of messages returned from Chocolatey
 {2} = The message of the exception that is being thrown</comment>
   </data>
   <data name="ChocolateyRemotePackageService_UpdateFailedTitle" xml:space="preserve">
-    <value>Failed to update package.</value>
+    <value>Failed to upgrade package.</value>
   </data>
   <data name="Controls_PackageListByAuthor" xml:space="preserve">
     <value>By: </value>
@@ -204,7 +204,7 @@ Error: {1}{2}</value>
     <value>Install</value>
   </data>
   <data name="Controls_PackagesContextMenuPin" xml:space="preserve">
-    <value>Pin (Ignore Updates)</value>
+    <value>Pin (Ignore Upgrades)</value>
   </data>
   <data name="Controls_PackagesContextMenuReinstall" xml:space="preserve">
     <value>Reinstall</value>
@@ -216,7 +216,7 @@ Error: {1}{2}</value>
     <value>Unpin</value>
   </data>
   <data name="Controls_PackagesContextMenuUpdate" xml:space="preserve">
-    <value>Update</value>
+    <value>Upgrade</value>
   </data>
   <data name="LocalSourceViewModel_Chocolatey" xml:space="preserve">
     <value>Chocolatey</value>
@@ -229,7 +229,7 @@ Error: {1}{2}</value>
     <value>Packages</value>
   </data>
   <data name="LocalSourceViewModel_UpdateAvailableForChocolatey" xml:space="preserve">
-    <value>There's an update available for Chocolatey.</value>
+    <value>There's an upgrade available for Chocolatey.</value>
   </data>
   <data name="LocalSourceView_ButtonExport" xml:space="preserve">
     <value>Export</value>
@@ -244,13 +244,13 @@ Error: {1}{2}</value>
     <value>Check for outdated packages (forced)</value>
   </data>
   <data name="LocalSourceView_ButtonUpdateAll" xml:space="preserve">
-    <value>Update All</value>
+    <value>Upgrade All</value>
   </data>
   <data name="LocalSourceView_CheckboxMatchExact" xml:space="preserve">
     <value>Match Word Exactly</value>
   </data>
   <data name="LocalSourceView_CheckboxPkgsWithUpdates" xml:space="preserve">
-    <value>Show Only Packages with Updates</value>
+    <value>Show Only Packages with Upgrades</value>
   </data>
   <data name="LocalSourceView_Grid_Authors" xml:space="preserve">
     <value>Authors</value>
@@ -287,7 +287,7 @@ Error: {1}{2}</value>
     <value>Failed to Unpin</value>
   </data>
   <data name="PackageViewModel_FailedToUpdate" xml:space="preserve">
-    <value>Failed to Update</value>
+    <value>Failed to Upgrade</value>
   </data>
   <data name="PackageViewModel_InstallingPackage" xml:space="preserve">
     <value>Installing package</value>
@@ -359,7 +359,7 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
     <value>Install</value>
   </data>
   <data name="PackageView_ButtonPin" xml:space="preserve">
-    <value>Pin (Ignore Updates)</value>
+    <value>Pin (Ignore Upgrades)</value>
   </data>
   <data name="PackageView_ButtonReinstall" xml:space="preserve">
     <value>Reinstall</value>
@@ -371,7 +371,7 @@ NOTE: Probably only necessary to change in RTL languages.</comment>
     <value>Unpin</value>
   </data>
   <data name="PackageView_ButtonUpdate" xml:space="preserve">
-    <value>Update</value>
+    <value>Upgrade</value>
   </data>
   <data name="PackageView_Dependencies" xml:space="preserve">
     <value>Dependencies</value>
@@ -1035,10 +1035,10 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Unpin from the currently installed package version</value>
   </data>
   <data name="Application_OperationUpgrade" xml:space="preserve">
-    <value>Update the currently installed package version</value>
+    <value>Upgrade the currently installed package version</value>
   </data>
   <data name="LocalSourceView_ButtonUpdateAllDisabled" xml:space="preserve">
-    <value>No packages need to be updated</value>
+    <value>No packages need to be upgraded</value>
   </data>
   <data name="AdvancedChocolateyDialog_AdvancedOptions_Header" xml:space="preserve">
     <value>Advanced Options</value>
@@ -1230,7 +1230,7 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Controls whether or not the This PC source is displayed in Chocolatey GUI.  Enabling this feature means that Chocolatey GUI will no longer show a list of all the currently installed packages on the machine.  NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.</value>
   </data>
   <data name="SettingsView_TogglePreventUsageOfUpdateAllButtonDescription" xml:space="preserve">
-    <value>Prevents the ability for user to use the Update All button. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.</value>
+    <value>Prevents the ability for user to use the Upgrade All button. NOTE: This feature will only work with Chocolatey for Business and the Chocolatey GUI licensed extension installed.</value>
   </data>
   <data name="SettingsView_ToggleSkipModalDialogConfirmationDescription" xml:space="preserve">
     <value>Skip modal dialog confirmations when performing potentially destructive actions.</value>
@@ -1294,7 +1294,7 @@ Please contact your System Administrator to enable this operation.</value>
     <value>Prevent Preload</value>
   </data>
   <data name="ChocolateyGUI_PreventUsageOfUpdateAllButtonTitle" xml:space="preserve">
-    <value>Prevent Usage of Update All Button</value>
+    <value>Prevent Usage of Upgrade All Button</value>
   </data>
   <data name="ChocolateyGUI_SkipModalDialogConfirmationTitle" xml:space="preserve">
     <value>Skip Modal Dialog Confirmation</value>


### PR DESCRIPTION
## Description Of Changes

* Replace "Update" terminology with "Upgrade" throughout the application
* Update resource strings to use consistent "Upgrade" terminology
* Change button labels from "Update" to "Upgrade"
* Modify context menu items to use "Upgrade" terminology
* Update error messages to reference "upgrade" operations
* Change checkbox and filter labels to use "Upgrade"
* Update pin feature descriptions to "Ignore Upgrades"

## Motivation and Context

Standardize terminology across the application for clarity and consistency. Align with Chocolatey's official package management operation naming conventions to improve user understanding of package operations.

## Testing

_NOTE: It was attempted to create UI tests related to this, but this had been unsuccessful_

_NOTE 2: Ensure that you have at least 1 outdated package installed that is visible to Chocolatey GUI (If using debug version of Chocolatey CLI, you may have to copy an outdated package directory from the globally installed Chocolatey CLI version into a lib folder in the Chocolatey GUI debug directory)_

1. Go to the `This PC` view.
2. Verify that the second checkbox have the text `Show Only Packages With Upgrades`
3. Right click on the outdated package, and Verify it mentions `Upgrade` in the context menu.
4. Also verify the context menu item have the tooltip: `Upgrade the currently installed package version`
5. Verify there is also a context menu item saying: `Pin (Ignore Upgrades)`
6. Hover of each of the menu items, which should have the following context menu tooltip text:
7. Hover of the icon in the image: <img width="47" height="36" alt="image" src="https://github.com/user-attachments/assets/a3084829-5dbc-4697-9297-0a98699ac1c7" />
8. Verify the tooltip says: `Upgrade All`
9. Double click the outdated package.
10. Verify there is a button saying `Upgrade`.
11. Hover of the `Upgrade` button, and verify that the tooltip say: `Upgrade the currently installed package version`
12. Verify that there is a button saying `Pin (Ignore Upgrades)`.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #937