### PR TITLE
(#1048) Replace Pagination With Infinite Scroll

### DIFF
--- a/Source/ChocolateyGui.Common.Windows.Tests/ViewModels/RemoteSourceViewModelTests.cs
+++ b/Source/ChocolateyGui.Common.Windows.Tests/ViewModels/RemoteSourceViewModelTests.cs
@@ -125,6 +125,133 @@ namespace ChocolateyGui.Common.Windows.Tests.ViewModels
             viewModel.Packages[0].IsInstalled.Should().BeTrue();
         }
 
+        [Test]
+        public void LoadPackages_PrefetchesTwoAdditionalPages()
+        {
+            var chocolateyService = BuildChocolateyService(
+                remote: new[]
+                {
+                    Package("alpha", "1.0.0"),
+                    Package("bravo", "1.0.0"),
+                    Package("charlie", "1.0.0"),
+                    Package("delta", "1.0.0"),
+                    Package("echo", "1.0.0"),
+                    Package("foxtrot", "1.0.0"),
+                    Package("golf", "1.0.0"),
+                    Package("hotel", "1.0.0"),
+                },
+                installed: Array.Empty<Package>());
+
+            var viewModel = BuildViewModel(chocolateyService, includeAllVersions: false);
+            viewModel.PageSize = 2;
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+
+            // First page plus two prefetched pages, so the next icons are ready before the user reaches the bottom.
+            viewModel.Packages.Select(p => p.Id).Should().Equal("alpha", "bravo", "charlie", "delta", "echo", "foxtrot");
+            viewModel.HasMore.Should().BeTrue();
+            viewModel.TotalCount.Should().Be(8);
+            chocolateyService.Verify(
+                s => s.Search(It.IsAny<string>(), It.IsAny<PackageSearchOptions>()),
+                Times.Exactly(3));
+            chocolateyService.Verify(s => s.GetInstalledPackages(), Times.Once);
+        }
+
+        [Test]
+        public void LoadMorePackages_AppendsNextBatch_WithoutClearing()
+        {
+            var chocolateyService = BuildChocolateyService(
+                remote: new[]
+                {
+                    Package("alpha", "1.0.0"),
+                    Package("bravo", "1.0.0"),
+                    Package("charlie", "1.0.0"),
+                    Package("delta", "1.0.0"),
+                    Package("echo", "1.0.0"),
+                    Package("foxtrot", "1.0.0"),
+                    Package("golf", "1.0.0"),
+                    Package("hotel", "1.0.0"),
+                },
+                installed: Array.Empty<Package>());
+
+            var viewModel = BuildViewModel(chocolateyService, includeAllVersions: false);
+            viewModel.PageSize = 2;
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+            viewModel.Packages.Should().HaveCount(6);
+
+            viewModel.LoadMorePackages().GetAwaiter().GetResult();
+
+            viewModel.Packages.Select(p => p.Id).Should().Equal(
+                "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel");
+            viewModel.LoadedCount.Should().Be(8);
+
+            // A full final page cannot prove the feed is exhausted; the next fetch is empty.
+            viewModel.HasMore.Should().BeTrue();
+            viewModel.LoadMorePackages().GetAwaiter().GetResult();
+            viewModel.HasMore.Should().BeFalse();
+            viewModel.LoadedCount.Should().Be(8);
+
+            chocolateyService.Verify(s => s.GetInstalledPackages(), Times.Once);
+        }
+
+        [Test]
+        public void LoadMorePackages_WhenLastBatchIsShort_DoesNotFetchAgain()
+        {
+            var chocolateyService = BuildChocolateyService(
+                remote: new[]
+                {
+                    Package("alpha", "1.0.0"),
+                    Package("bravo", "1.0.0"),
+                    Package("charlie", "1.0.0"),
+                },
+                installed: Array.Empty<Package>());
+
+            var viewModel = BuildViewModel(chocolateyService, includeAllVersions: false);
+            viewModel.PageSize = 2;
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+            viewModel.LoadMorePackages().GetAwaiter().GetResult();
+
+            chocolateyService.Verify(
+                s => s.Search(It.IsAny<string>(), It.IsAny<PackageSearchOptions>()),
+                Times.Exactly(2));
+            viewModel.Packages.Should().HaveCount(3);
+            viewModel.HasMore.Should().BeFalse();
+        }
+
+        [Test]
+        public void LoadPackages_AfterAppend_ReplacesPreviouslyLoadedItems()
+        {
+            var chocolateyService = BuildChocolateyService(
+                remote: new[]
+                {
+                    Package("alpha", "1.0.0"),
+                    Package("bravo", "1.0.0"),
+                    Package("charlie", "1.0.0"),
+                    Package("delta", "1.0.0"),
+                    Package("echo", "1.0.0"),
+                    Package("foxtrot", "1.0.0"),
+                    Package("golf", "1.0.0"),
+                    Package("hotel", "1.0.0"),
+                    Package("india", "1.0.0"),
+                    Package("juliet", "1.0.0"),
+                },
+                installed: Array.Empty<Package>());
+
+            var viewModel = BuildViewModel(chocolateyService, includeAllVersions: false);
+            viewModel.PageSize = 2;
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+            viewModel.LoadMorePackages().GetAwaiter().GetResult();
+            viewModel.Packages.Should().HaveCount(8);
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+
+            viewModel.Packages.Select(p => p.Id).Should().Equal("alpha", "bravo", "charlie", "delta", "echo", "foxtrot");
+            viewModel.HasMore.Should().BeTrue();
+        }
+
         private static IPackageViewModel CreatePackageViewModelStub()
         {
             var packageViewModel = new Mock<IPackageViewModel>();
@@ -148,7 +275,16 @@ namespace ChocolateyGui.Common.Windows.Tests.ViewModels
             var service = new Mock<IChocolateyService>();
 
             service.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<PackageSearchOptions>()))
-                .ReturnsAsync(new PackageResults { Packages = remote, TotalCount = remote.Length });
+                .Returns((string _, PackageSearchOptions options) =>
+                {
+                    var pageSize = options.PageSize > 0 ? options.PageSize : remote.Length;
+                    var packages = remote.Skip(options.CurrentPage * pageSize).Take(pageSize).ToArray();
+                    return Task.FromResult(new PackageResults
+                    {
+                        Packages = packages,
+                        TotalCount = remote.Length
+                    });
+                });
 
             service.Setup(s => s.GetInstalledPackages())
                 .ReturnsAsync(installed.AsEnumerable());

--- a/Source/ChocolateyGui.Common.Windows.Tests/ViewModels/RemoteSourceViewModelTests.cs
+++ b/Source/ChocolateyGui.Common.Windows.Tests/ViewModels/RemoteSourceViewModelTests.cs
@@ -252,6 +252,36 @@ namespace ChocolateyGui.Common.Windows.Tests.ViewModels
             viewModel.HasMore.Should().BeTrue();
         }
 
+        [Test]
+        public void LoadPackages_WhenTotalCountIsUnknown_DoesNotShowNegativeTotal()
+        {
+            var chocolateyService = new Mock<IChocolateyService>();
+            chocolateyService.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<PackageSearchOptions>()))
+                .Returns((string _, PackageSearchOptions options) =>
+                {
+                    var packages = options.CurrentPage == 0
+                        ? new[] { Package("alpha", "1.0.0") }
+                        : Array.Empty<Package>();
+                    return Task.FromResult(new PackageResults
+                    {
+                        Packages = packages,
+                        TotalCount = -1,
+                    });
+                });
+            chocolateyService.Setup(s => s.GetInstalledPackages())
+                .ReturnsAsync(Array.Empty<Package>().AsEnumerable());
+            chocolateyService.Setup(s => s.GetOutdatedPackages(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ChocolateySource>()))
+                .ReturnsAsync((IReadOnlyList<OutdatedPackage>)new List<OutdatedPackage>());
+
+            var viewModel = BuildViewModel(chocolateyService, includeAllVersions: true);
+
+            viewModel.LoadPackages(false).GetAwaiter().GetResult();
+
+            viewModel.Packages.Should().HaveCount(1);
+            viewModel.TotalCount.Should().Be(1);
+            viewModel.HasMore.Should().BeFalse();
+        }
+
         private static IPackageViewModel CreatePackageViewModelStub()
         {
             var packageViewModel = new Mock<IPackageViewModel>();

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -340,9 +340,7 @@ namespace ChocolateyGui.Common.Windows.Services
                 return new PackageResults
                 {
                     Packages = packages.ToArray(),
-                    TotalCount = options.IncludeTotalCount
-                        ? await Task.Run(() => _choco.ListCount())
-                        : 0
+                    TotalCount = options.IncludeTotalCount ? _choco.ListCount() : 0
                 };
             }
         }

--- a/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
+++ b/Source/ChocolateyGui.Common.Windows/Services/ChocolateyService.cs
@@ -340,7 +340,9 @@ namespace ChocolateyGui.Common.Windows.Services
                 return new PackageResults
                 {
                     Packages = packages.ToArray(),
-                    TotalCount = await Task.Run(() => _choco.ListCount())
+                    TotalCount = options.IncludeTotalCount
+                        ? await Task.Run(() => _choco.ListCount())
+                        : 0
                 };
             }
         }

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -380,6 +380,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                     ShowShouldPreventPreloadMessage = false;
                     _nextPage = 0;
                     HasMore = true;
+                    TotalCount = 0;
                     Packages.Clear();
                     NotifyListCounts();
                 }
@@ -421,26 +422,16 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                                     IncludeAllVersions,
                                     MatchWord,
                                     Source.Value,
-                                    reset && page == 0));
+                                    false));
 
                             if (loadId != _loadId)
                             {
                                 return;
                             }
 
-                            added = await ApplySearchResultAsync(result, reset, page);
+                            added = await ApplySearchResultAsync(result, reset, page, loadId);
                         }
-                        while (added == 0 && HasMore);
-
-                        if (reset)
-                        {
-                            var outdatedPackages = await GetOutdatedPackagesAsync(forceCheckForOutdatedPackages);
-
-                            foreach (var update in outdatedPackages)
-                            {
-                                await _eventAggregator.PublishOnUIThreadAsync(new PackageOutdatedMessage(update.Id, update.Version, source: Source));
-                            }
-                        }
+                        while (added == 0 && HasMore && loadId == _loadId);
                     }
                     finally
                     {
@@ -453,6 +444,26 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
                     if (reset && loadId == _loadId)
                     {
+                        // Outdated check and prefetch run after the modal closes so the list is usable.
+                        try
+                        {
+                            var outdatedPackages = await GetOutdatedPackagesAsync(forceCheckForOutdatedPackages);
+
+                            foreach (var update in outdatedPackages)
+                            {
+                                if (loadId != _loadId)
+                                {
+                                    break;
+                                }
+
+                                await _eventAggregator.PublishOnUIThreadAsync(new PackageOutdatedMessage(update.Id, update.Version, source: Source));
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex, "Failed to check for outdated packages after remote load.");
+                        }
+
                         // Do not await: extra pages arrive in the background so the list stays interactive.
 #pragma warning disable 4014
                         PrefetchAhead(loadId);
@@ -523,30 +534,63 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             // Chocolatey search is expensive; keep it off the dispatcher so scrolling stays responsive.
             if (Application.Current != null)
             {
-                return await Task.Run(() => _chocolateyPackageService.Search(SearchQuery, options)).ConfigureAwait(false);
+                return await Task.Run(async () =>
+                    await _chocolateyPackageService.Search(SearchQuery, options).ConfigureAwait(false)).ConfigureAwait(false);
             }
 
             return await _chocolateyPackageService.Search(SearchQuery, options);
         }
 
-        private async Task<int> ApplySearchResultAsync(PackageResults result, bool reset, int page)
+        private async Task<int> ApplySearchResultAsync(PackageResults result, bool reset, int page, int loadId)
         {
+            if (loadId != _loadId)
+            {
+                return 0;
+            }
+
             var fetchedCount = result.Packages == null ? 0 : result.Packages.Length;
             var viewModels = Application.Current != null
                 ? await Task.Run(() => CreatePackageViewModels(result.Packages)).ConfigureAwait(false)
                 : CreatePackageViewModels(result.Packages);
 
-            var added = await AddViewModelsAsync(viewModels);
+            if (loadId != _loadId)
+            {
+                return 0;
+            }
+
+            var added = await AddViewModelsAsync(viewModels, loadId);
+
+            if (loadId != _loadId)
+            {
+                return 0;
+            }
 
             System.Action commitPage = () =>
             {
+                if (loadId != _loadId)
+                {
+                    return;
+                }
+
                 if (reset && page == 0)
                 {
-                    TotalCount = result.TotalCount;
+                    // Totals from ListCount are skipped (can hang). Seed from this page; HasMore
+                    // keeps loading until a short page arrives.
+                    TotalCount = result.TotalCount > 0 ? result.TotalCount : fetchedCount;
                 }
 
                 _nextPage = page + 1;
                 HasMore = fetchedCount >= PageSize;
+                if (TotalCount < LoadedCount)
+                {
+                    TotalCount = LoadedCount;
+                }
+
+                if (!HasMore)
+                {
+                    TotalCount = LoadedCount;
+                }
+
                 NotifyListCounts();
             };
 
@@ -627,9 +671,9 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             return viewModels;
         }
 
-        private async Task<int> AddViewModelsAsync(IList<IPackageViewModel> viewModels)
+        private async Task<int> AddViewModelsAsync(IList<IPackageViewModel> viewModels, int loadId)
         {
-            if (viewModels == null || viewModels.Count == 0)
+            if (viewModels == null || viewModels.Count == 0 || loadId != _loadId)
             {
                 return 0;
             }
@@ -646,17 +690,29 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                 return viewModels.Count;
             }
 
+            var added = 0;
             for (var index = 0; index < viewModels.Count; index += UiAddChunkSize)
             {
+                if (loadId != _loadId)
+                {
+                    return added;
+                }
+
                 var start = index;
                 var count = Math.Min(UiAddChunkSize, viewModels.Count - index);
                 await dispatcher.InvokeAsync(() =>
                 {
+                    if (loadId != _loadId)
+                    {
+                        return;
+                    }
+
                     for (var offset = 0; offset < count; offset++)
                     {
                         Packages.Add(viewModels[start + offset]);
                     }
 
+                    added += count;
                     NotifyListCounts();
                 }).Task.ConfigureAwait(false);
 
@@ -664,7 +720,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels
                 await dispatcher.InvokeAsync(() => { }, DispatcherPriority.Input).Task.ConfigureAwait(false);
             }
 
-            return viewModels.Count;
+            return added;
         }
 
         private void NotifyListCounts()

--- a/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/RemoteSourceViewModel.cs
@@ -6,6 +6,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
@@ -14,6 +15,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
+using System.Windows.Threading;
 using AutoMapper;
 using Caliburn.Micro;
 using ChocolateyGui.Common.Enums;
@@ -27,7 +29,6 @@ using ChocolateyGui.Common.ViewModels.Items;
 using ChocolateyGui.Common.Windows.Services;
 using ChocolateyGui.Common.Windows.Utilities;
 using ChocolateyGui.Common.Windows.Utilities.Extensions;
-using NuGet.Packaging;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -35,6 +36,9 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 {
     public sealed class RemoteSourceViewModel : ViewModelScreen, ISourceViewModelBase
     {
+        private const int PrefetchPageCount = 2;
+        private const int UiAddChunkSize = 5;
+
         private static readonly ILogger Logger = Log.ForContext<RemoteSourceViewModel>();
         private readonly IChocolateyService _chocolateyPackageService;
         private readonly IDialogService _dialogService;
@@ -43,15 +47,19 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         private readonly IConfigService _configService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IMapper _mapper;
-        private int _currentPage = 1;
         private bool _hasLoaded;
+        private bool _hasMore;
+        private bool _isLoadingMore;
         private bool _shouldShowPreventPreloadMessage;
         private bool _includeAllVersions;
         private bool _includePrerelease;
         private bool _matchWord;
         private ObservableCollection<IPackageViewModel> _packageViewModels;
-        private int _pageCount = 1;
         private int _pageSize = 50;
+        private int _totalCount;
+        private int _nextPage;
+        private int _loadId;
+        private IList<Package> _installedPackages = new List<Package>();
         private string _searchQuery;
         private string _sortSelection;
         private string _sortSelectionName;
@@ -117,6 +125,12 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             set { this.SetPropertyValue(ref _hasLoaded, value); }
         }
 
+        public bool HasMore
+        {
+            get { return _hasMore; }
+            set { this.SetPropertyValue(ref _hasMore, value); }
+        }
+
         public bool ShowShouldPreventPreloadMessage
         {
             get { return _shouldShowPreventPreloadMessage; }
@@ -145,10 +159,15 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         public ICollectionView PackageSource { get; }
 
-        public int CurrentPage
+        public int LoadedCount
         {
-            get { return _currentPage; }
-            set { this.SetPropertyValue(ref _currentPage, value); }
+            get { return Packages == null ? 0 : Packages.Count; }
+        }
+
+        public int TotalCount
+        {
+            get { return _totalCount; }
+            set { this.SetPropertyValue(ref _totalCount, value); }
         }
 
         public bool IncludeAllVersions
@@ -167,12 +186,6 @@ namespace ChocolateyGui.Common.Windows.ViewModels
         {
             get { return _matchWord; }
             set { this.SetPropertyValue(ref _matchWord, value); }
-        }
-
-        public int PageCount
-        {
-            get { return _pageCount; }
-            set { this.SetPropertyValue(ref _pageCount, value); }
         }
 
         public int PageSize
@@ -205,52 +218,6 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             }
         }
 
-        public bool CanGoToFirst()
-        {
-            return CurrentPage > 1;
-        }
-
-        public bool CanGoToLast()
-        {
-            return CurrentPage < PageCount;
-        }
-
-        public bool CanGoToNext()
-        {
-            return CurrentPage < PageCount;
-        }
-
-        public bool CanGoToPrevious()
-        {
-            return CurrentPage > 1;
-        }
-
-        public void GoToFirst()
-        {
-            CurrentPage = 1;
-        }
-
-        public void GoToLast()
-        {
-            CurrentPage = PageCount;
-        }
-
-        public void GoToNext()
-        {
-            if (CurrentPage < PageCount)
-            {
-                CurrentPage++;
-            }
-        }
-
-        public void GoToPrevious()
-        {
-            if (CurrentPage > 1)
-            {
-                CurrentPage--;
-            }
-        }
-
         public bool CanSearchForPackages()
         {
             return HasLoaded;
@@ -277,129 +244,17 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 
         public async Task LoadPackages(bool forceCheckForOutdatedPackages)
         {
-            try
+            await LoadPackages(true, forceCheckForOutdatedPackages);
+        }
+
+        public async Task LoadMorePackages()
+        {
+            if (!HasLoaded || _isLoadingMore || !HasMore)
             {
-                if (!IsActive || (!CanLoadRemotePackages() && Packages.Any()))
-                {
-                    return;
-                }
-
-                if (!HasLoaded && (_configService.GetEffectiveConfiguration().PreventPreload ?? false))
-                {
-                    ShowShouldPreventPreloadMessage = true;
-                    HasLoaded = true;
-                    return;
-                }
-
-                HasLoaded = false;
-                ShowShouldPreventPreloadMessage = false;
-
-                var sort = _sortSelectionName;
-
-                await _progressService.StartLoading(L(nameof(Resources.RemoteSourceViewModel_LoadingPage), CurrentPage));
-
-                _progressService.WriteMessage(L(nameof(Resources.RemoteSourceViewModel_FetchingPackages)));
-
-                try
-                {
-                    var result =
-                        await
-                            _chocolateyPackageService.Search(
-                                SearchQuery,
-                                new PackageSearchOptions(
-                                    PageSize,
-                                    CurrentPage - 1,
-                                    sort,
-                                    IncludePrerelease,
-                                    IncludeAllVersions,
-                                    MatchWord,
-                                    Source.Value));
-                    var installedPackages = await _chocolateyPackageService.GetInstalledPackages();
-                    
-                    PackageSource.Refresh();
-
-                    PageCount = (int)Math.Ceiling((double)result.TotalCount / (double)PageSize);
-                    Packages.Clear();
-
-                    // When showing all versions, the source returns them in the active sort order (e.g.
-                    // popularity / download count), which interleaves the versions of a package. Order each
-                    // package's versions newest-first, keeping the packages themselves in their original
-                    // (relevance) order.
-                    var packagesToDisplay = IncludeAllVersions
-                        ? result.Packages
-                            .GroupBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
-                            .SelectMany(group => group.OrderByDescending(package => package.Version))
-                            .ToList()
-                        : result.Packages.ToList();
-
-                    packagesToDisplay.ForEach(p =>
-                    {
-                        var remoteVersion = p.Version;
-
-                        if (IncludeAllVersions)
-                        {
-                            // When showing all versions, every row is a distinct version of the same package.
-                            // Only flag the row whose version is actually installed, and never overwrite the
-                            // displayed version - otherwise every row collapses to the installed version (#1146).
-                            var installedVersion = installedPackages.FirstOrDefault(package =>
-                                string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase)
-                                && Equals(package.Version, p.Version));
-                            if (installedVersion != null)
-                            {
-                                p.IsPinned = installedVersion.IsPinned;
-                                p.IsInstalled = true;
-                            }
-                        }
-                        else
-                        {
-                            var installedPackage = installedPackages.FirstOrDefault(package => string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase));
-                            if (installedPackage != null)
-                            {
-                                p.Version = installedPackage.Version;
-                                p.IsPinned = installedPackage.IsPinned;
-                                p.IsInstalled = true;
-                            }
-                        }
-
-                        var packageViewModel = Mapper.Map<IPackageViewModel>(p);
-                        packageViewModel.ChocolateySource = Source;
-                        packageViewModel.RemoteVersion = remoteVersion;
-                        Packages.Add(packageViewModel);
-                    });
-
-                    if (_configService.GetEffectiveConfiguration().ExcludeInstalledPackages ?? false)
-                    {
-                        Packages.RemoveAll(x => x.IsInstalled);
-                    }
-
-                    if (PageCount < CurrentPage)
-                    {
-                        CurrentPage = PageCount == 0 ? 1 : PageCount;
-                    }
-
-                    var outdatedPackages = await _chocolateyPackageService.GetOutdatedPackages(IncludePrerelease, forceCheckForOutdatedPackages: forceCheckForOutdatedPackages, source: Source);
-
-                    foreach (var update in outdatedPackages)
-                    {
-                        await _eventAggregator.PublishOnUIThreadAsync(new PackageOutdatedMessage(update.Id, update.Version, source: Source));
-                    }
-                }
-                finally
-                {
-                    await _progressService.StopLoading();
-                    HasLoaded = true;
-                }
-
-                await _eventAggregator.PublishOnUIThreadAsync(new ResetScrollPositionMessage());
+                return;
             }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to load new packages.");
-                await _dialogService.ShowMessageAsync(
-                    L(nameof(Resources.RemoteSourceViewModel_FailedToLoad)),
-                    L(nameof(Resources.RemoteSourceViewModel_FailedToLoadRemotePackages), ex.Message));
-                throw;
-            }
+
+            await LoadPackages(false, false);
         }
 
         public bool CanCheckForOutdatedPackages()
@@ -465,15 +320,6 @@ namespace ChocolateyGui.Common.Windows.ViewModels
 #pragma warning disable 4014
                     .Subscribe(e => LoadPackages(false));
 #pragma warning restore 4014
-
-                Observable.FromEventPattern<PropertyChangedEventArgs>(this, "PropertyChanged")
-                    .Where(e => e.EventArgs.PropertyName == "CurrentPage")
-                    .Throttle(TimeSpan.FromMilliseconds(300))
-                    .DistinctUntilChanged()
-                    .ObserveOnDispatcher()
-#pragma warning disable 4014
-                    .Subscribe(e => LoadPackages(false));
-#pragma warning restore 4014
             }
             catch (InvalidOperationException ex)
             {
@@ -504,6 +350,328 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             RemoveOldSortOptions();
         }
 
+        private async Task LoadPackages(bool reset, bool forceCheckForOutdatedPackages)
+        {
+            try
+            {
+                if (!IsActive || (!CanLoadRemotePackages() && Packages.Any()))
+                {
+                    return;
+                }
+
+                if (reset && !HasLoaded && (_configService.GetEffectiveConfiguration().PreventPreload ?? false))
+                {
+                    ShowShouldPreventPreloadMessage = true;
+                    HasLoaded = true;
+                    HasMore = false;
+                    return;
+                }
+
+                if (!reset && (!HasLoaded || _isLoadingMore || !HasMore))
+                {
+                    return;
+                }
+
+                var loadId = reset ? ++_loadId : _loadId;
+
+                if (reset)
+                {
+                    HasLoaded = false;
+                    ShowShouldPreventPreloadMessage = false;
+                    _nextPage = 0;
+                    HasMore = true;
+                    Packages.Clear();
+                    NotifyListCounts();
+                }
+                else
+                {
+                    _isLoadingMore = true;
+                }
+
+                try
+                {
+                    if (reset)
+                    {
+                        await _progressService.StartLoading(L(nameof(Resources.RemoteSourceViewModel_FetchingPackages)));
+                        _progressService.WriteMessage(L(nameof(Resources.RemoteSourceViewModel_FetchingPackages)));
+                    }
+
+                    try
+                    {
+                        if (reset)
+                        {
+                            _installedPackages = (await GetInstalledPackagesAsync()).ToList();
+                        }
+
+                        var added = 0;
+                        do
+                        {
+                            if (loadId != _loadId)
+                            {
+                                return;
+                            }
+
+                            var page = _nextPage;
+                            var result = await SearchPackagesAsync(
+                                new PackageSearchOptions(
+                                    PageSize,
+                                    page,
+                                    _sortSelectionName,
+                                    IncludePrerelease,
+                                    IncludeAllVersions,
+                                    MatchWord,
+                                    Source.Value,
+                                    reset && page == 0));
+
+                            if (loadId != _loadId)
+                            {
+                                return;
+                            }
+
+                            added = await ApplySearchResultAsync(result, reset, page);
+                        }
+                        while (added == 0 && HasMore);
+
+                        if (reset)
+                        {
+                            var outdatedPackages = await GetOutdatedPackagesAsync(forceCheckForOutdatedPackages);
+
+                            foreach (var update in outdatedPackages)
+                            {
+                                await _eventAggregator.PublishOnUIThreadAsync(new PackageOutdatedMessage(update.Id, update.Version, source: Source));
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (reset)
+                        {
+                            await _progressService.StopLoading();
+                            HasLoaded = true;
+                        }
+                    }
+
+                    if (reset && loadId == _loadId)
+                    {
+                        // Do not await: extra pages arrive in the background so the list stays interactive.
+#pragma warning disable 4014
+                        PrefetchAhead(loadId);
+#pragma warning restore 4014
+                        await _eventAggregator.PublishOnUIThreadAsync(new ResetScrollPositionMessage());
+                    }
+                }
+                finally
+                {
+                    if (!reset)
+                    {
+                        _isLoadingMore = false;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to load new packages.");
+                await _dialogService.ShowMessageAsync(
+                    L(nameof(Resources.RemoteSourceViewModel_FailedToLoad)),
+                    L(nameof(Resources.RemoteSourceViewModel_FailedToLoadRemotePackages), ex.Message));
+                throw;
+            }
+        }
+
+        private async Task PrefetchAhead(int loadId)
+        {
+            try
+            {
+                for (var i = 0; i < PrefetchPageCount; i++)
+                {
+                    if (loadId != _loadId || !HasMore)
+                    {
+                        return;
+                    }
+
+                    await LoadPackages(false, false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to prefetch packages.");
+            }
+        }
+
+        private async Task<IEnumerable<Package>> GetInstalledPackagesAsync()
+        {
+            if (Application.Current != null)
+            {
+                return await Task.Run(() => _chocolateyPackageService.GetInstalledPackages()).ConfigureAwait(false);
+            }
+
+            return await _chocolateyPackageService.GetInstalledPackages();
+        }
+
+        private async Task<IReadOnlyList<OutdatedPackage>> GetOutdatedPackagesAsync(bool forceCheckForOutdatedPackages)
+        {
+            if (Application.Current != null)
+            {
+                return await Task.Run(() => _chocolateyPackageService.GetOutdatedPackages(IncludePrerelease, forceCheckForOutdatedPackages, Source)).ConfigureAwait(false);
+            }
+
+            return await _chocolateyPackageService.GetOutdatedPackages(IncludePrerelease, forceCheckForOutdatedPackages, Source);
+        }
+
+        private async Task<PackageResults> SearchPackagesAsync(PackageSearchOptions options)
+        {
+            // Chocolatey search is expensive; keep it off the dispatcher so scrolling stays responsive.
+            if (Application.Current != null)
+            {
+                return await Task.Run(() => _chocolateyPackageService.Search(SearchQuery, options)).ConfigureAwait(false);
+            }
+
+            return await _chocolateyPackageService.Search(SearchQuery, options);
+        }
+
+        private async Task<int> ApplySearchResultAsync(PackageResults result, bool reset, int page)
+        {
+            var fetchedCount = result.Packages == null ? 0 : result.Packages.Length;
+            var viewModels = Application.Current != null
+                ? await Task.Run(() => CreatePackageViewModels(result.Packages)).ConfigureAwait(false)
+                : CreatePackageViewModels(result.Packages);
+
+            var added = await AddViewModelsAsync(viewModels);
+
+            System.Action commitPage = () =>
+            {
+                if (reset && page == 0)
+                {
+                    TotalCount = result.TotalCount;
+                }
+
+                _nextPage = page + 1;
+                HasMore = fetchedCount >= PageSize;
+                NotifyListCounts();
+            };
+
+            var dispatcher = Application.Current != null ? Application.Current.Dispatcher : null;
+            if (dispatcher != null && !dispatcher.CheckAccess())
+            {
+                await dispatcher.InvokeAsync(commitPage).Task.ConfigureAwait(false);
+            }
+            else
+            {
+                commitPage();
+            }
+
+            return added;
+        }
+
+        private IList<IPackageViewModel> CreatePackageViewModels(IEnumerable<Package> packages)
+        {
+            var viewModels = new List<IPackageViewModel>();
+            if (packages == null)
+            {
+                return viewModels;
+            }
+
+            var installedPackages = _installedPackages ?? new List<Package>();
+
+            // When showing all versions, the source returns them in the active sort order (e.g.
+            // popularity / download count), which interleaves the versions of a package. Order each
+            // package's versions newest-first, keeping the packages themselves in their original
+            // (relevance) order.
+            var packagesToDisplay = IncludeAllVersions
+                ? packages
+                    .GroupBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
+                    .SelectMany(group => group.OrderByDescending(package => package.Version))
+                    .ToList()
+                : packages.ToList();
+
+            packagesToDisplay.ForEach(p =>
+            {
+                var remoteVersion = p.Version;
+
+                if (IncludeAllVersions)
+                {
+                    // When showing all versions, every row is a distinct version of the same package.
+                    // Only flag the row whose version is actually installed, and never overwrite the
+                    // displayed version - otherwise every row collapses to the installed version (#1146).
+                    var installedVersion = installedPackages.FirstOrDefault(package =>
+                        string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase)
+                        && Equals(package.Version, p.Version));
+                    if (installedVersion != null)
+                    {
+                        p.IsPinned = installedVersion.IsPinned;
+                        p.IsInstalled = true;
+                    }
+                }
+                else
+                {
+                    var installedPackage = installedPackages.FirstOrDefault(package => string.Equals(package.Id, p.Id, StringComparison.OrdinalIgnoreCase));
+                    if (installedPackage != null)
+                    {
+                        p.Version = installedPackage.Version;
+                        p.IsPinned = installedPackage.IsPinned;
+                        p.IsInstalled = true;
+                    }
+                }
+
+                var packageViewModel = Mapper.Map<IPackageViewModel>(p);
+                packageViewModel.ChocolateySource = Source;
+                packageViewModel.RemoteVersion = remoteVersion;
+                viewModels.Add(packageViewModel);
+            });
+
+            if (_configService.GetEffectiveConfiguration().ExcludeInstalledPackages ?? false)
+            {
+                viewModels.RemoveAll(package => package.IsInstalled);
+            }
+
+            return viewModels;
+        }
+
+        private async Task<int> AddViewModelsAsync(IList<IPackageViewModel> viewModels)
+        {
+            if (viewModels == null || viewModels.Count == 0)
+            {
+                return 0;
+            }
+
+            var dispatcher = Application.Current != null ? Application.Current.Dispatcher : null;
+            if (dispatcher == null)
+            {
+                foreach (var packageViewModel in viewModels)
+                {
+                    Packages.Add(packageViewModel);
+                }
+
+                NotifyListCounts();
+                return viewModels.Count;
+            }
+
+            for (var index = 0; index < viewModels.Count; index += UiAddChunkSize)
+            {
+                var start = index;
+                var count = Math.Min(UiAddChunkSize, viewModels.Count - index);
+                await dispatcher.InvokeAsync(() =>
+                {
+                    for (var offset = 0; offset < count; offset++)
+                    {
+                        Packages.Add(viewModels[start + offset]);
+                    }
+
+                    NotifyListCounts();
+                }).Task.ConfigureAwait(false);
+
+                // Let scroll input and layout run before the next tiles are materialized.
+                await dispatcher.InvokeAsync(() => { }, DispatcherPriority.Input).Task.ConfigureAwait(false);
+            }
+
+            return viewModels.Count;
+        }
+
+        private void NotifyListCounts()
+        {
+            NotifyOfPropertyChange(nameof(LoadedCount));
+        }
+
         private void AddSortOptions()
         {
             var downloadCount = L(nameof(Resources.RemoteSourceViewModel_SortSelectionPopularity));
@@ -529,7 +697,13 @@ namespace ChocolateyGui.Common.Windows.ViewModels
             var downloadCount = L(nameof(Resources.RemoteSourceViewModel_SortSelectionPopularity));
             var title = L(nameof(Resources.RemoteSourceViewModel_SortSelectionAtoZ));
 
-            SortOptions.RemoveAll(so => so != downloadCount && so != title);
+            for (var index = SortOptions.Count - 1; index >= 0; index--)
+            {
+                if (SortOptions[index] != downloadCount && SortOptions[index] != title)
+                {
+                    SortOptions.RemoveAt(index);
+                }
+            }
         }
 
         private void SubscribeToLoadPackagesOnSearchQueryChange()

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml
@@ -534,58 +534,20 @@
             </StackPanel>
         </Grid>
 
-        <Grid Grid.Row="2" Margin="4" Grid.IsSharedSizeScope="True">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
-                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
-                <ColumnDefinition Width="3*" />
-                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
-                <ColumnDefinition Width="Auto" SharedSizeGroup="ButtonCol" />
-            </Grid.ColumnDefinitions>
-            <Button Grid.Column="0"
-                    Name="FirstPage"
-                    Content="{lang:Localize RemoteSourceView_ButtonGotoFirstPage}"
-                    AutomationProperties.Name="Go to First Page"
-                    ToolTip="{lang:Localize RemoteSourceView_TooltipGotoFirstPage}"
-                    Command="{commands:DataContextCommandAdapter Executed=GoToFirst, CanExecute=CanGoToFirst}"
-                    Style="{DynamicResource PaginationButtonStyle}"/>
-            <Button Grid.Column="1"
-                    Name="BackPage"
-                    Content="{lang:Localize RemoteSourceView_ButtonGoBackAPage}"
-                    AutomationProperties.Name="Go Back a Page"
-                    ToolTip="{lang:Localize RemoteSourceView_TooltipGoBackAPage}"
-                    Command="{commands:DataContextCommandAdapter Executed=GoToPrevious, CanExecute=CanGoToPrevious}"
-                    Style="{DynamicResource PaginationButtonStyle}"/>
-
-            <TextBlock Grid.Column="2"
-                       Name="CurrentPage"
-                       AutomationProperties.Name="Current Page"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Style="{StaticResource PageCountTextStyle}">
-                <TextBlock.Text>
-                    <MultiBinding StringFormat="{}{0} / {1}">
-                        <Binding Path="CurrentPage" Mode="OneWay" />
-                        <Binding Path="PageCount" Mode="OneWay" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
-
-            <Button Grid.Column="3"
-                    Name="ForwardPage"
-                    Content="{lang:Localize RemoteSourceView_ButtonGoForwardAPage}"
-                    AutomationProperties.Name="Go Forward a Page"
-                    ToolTip="{lang:Localize RemoteSourceView_TooltipGoForwardAPage}"
-                    Command="{commands:DataContextCommandAdapter Executed=GoToNext, CanExecute=CanGoToNext}"
-                    Style="{DynamicResource PaginationButtonStyle}"/>
-            <Button Grid.Column="4"
-                    Name="LastPage"
-                    Content="{lang:Localize RemoteSourceView_ButtonGotoLastPage}"
-                    AutomationProperties.Name="Go to Last Page"
-                    ToolTip="{lang:Localize RemoteSourceView_TooltipGotoLastPage}"
-                    Command="{commands:DataContextCommandAdapter Executed=GoToLast, CanExecute=CanGoToLast}"
-                    Style="{DynamicResource PaginationButtonStyle}"/>
-        </Grid>
+        <TextBlock Grid.Row="2"
+                   Name="PackageListStatus"
+                   Margin="4"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   AutomationProperties.Name="Package List Status"
+                   Style="{StaticResource PageCountTextStyle}">
+            <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0} / {1}">
+                    <Binding Path="LoadedCount" Mode="OneWay" />
+                    <Binding Path="TotalCount" Mode="OneWay" />
+                </MultiBinding>
+            </TextBlock.Text>
+        </TextBlock>
 
         <Grid Grid.Row="1">
             <ListView x:Name="Packages"
@@ -596,6 +558,7 @@
                       HorizontalContentAlignment="Stretch"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                       ScrollViewer.IsDeferredScrollingEnabled="False"
+                      ScrollViewer.ScrollChanged="Packages_OnScrollChanged"
                       MouseDoubleClick="Packages_OnMouseDoubleClick" />
 
             <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml.cs
+++ b/Source/ChocolateyGui.Common.Windows/Views/RemoteSourceView.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using Caliburn.Micro;
 using ChocolateyGui.Common.Models.Messages;
 using ChocolateyGui.Common.ViewModels.Items;
+using ChocolateyGui.Common.Windows.ViewModels;
 
 namespace ChocolateyGui.Common.Windows.Views
 {
@@ -46,6 +47,32 @@ namespace ChocolateyGui.Common.Windows.Views
         private void RemoteSourceViewOnLoaded(object sender, RoutedEventArgs e)
         {
             this.SearchTextBox.Focus();
+        }
+
+        private void Packages_OnScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            var scrollViewer = e.OriginalSource as ScrollViewer;
+            if (scrollViewer == null)
+            {
+                return;
+            }
+
+            var remaining = scrollViewer.ExtentHeight - scrollViewer.VerticalOffset - scrollViewer.ViewportHeight;
+            var shouldPrefetch = scrollViewer.ScrollableHeight <= 0
+                                 || remaining <= scrollViewer.ViewportHeight * 2;
+
+            if (!shouldPrefetch)
+            {
+                return;
+            }
+
+            var viewModel = DataContext as RemoteSourceViewModel;
+            if (viewModel != null)
+            {
+#pragma warning disable 4014
+                viewModel.LoadMorePackages();
+#pragma warning restore 4014
+            }
         }
 
         private void Packages_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/ChocolateyGui.Common/Models/PackageSearchOptions.cs
+++ b/Source/ChocolateyGui.Common/Models/PackageSearchOptions.cs
@@ -16,7 +16,8 @@ namespace ChocolateyGui.Common.Models
             bool includePrerelease,
             bool includeAllVersions,
             bool matchWord,
-            string source)
+            string source,
+            bool includeTotalCount = true)
             : this()
         {
             PageSize = pageSize;
@@ -26,9 +27,12 @@ namespace ChocolateyGui.Common.Models
             IncludePrerelease = includePrerelease;
             MatchQuery = matchWord;
             Source = source;
+            IncludeTotalCount = includeTotalCount;
         }
 
         public int CurrentPage { get; set;  }
+
+        public bool IncludeTotalCount { get; set; }
 
         public bool IncludeAllVersions { get; set; }
 


### PR DESCRIPTION
## Description Of Changes
Replace remote-source First/Back/Next/Last pagination with infinite scrolling.

- Remove the pager controls from the remote package list.
- Load the first batch of packages as before, then append more results as the user scrolls near the bottom.
- Prefetch additional batches ahead of the viewport so later icons are ready before the user reaches the end of the currently loaded list.
- Keep Chocolatey search and package mapping off the UI thread, and add tiles in small chunks, so scrolling stays responsive while more packages load.
- Show a simple `loaded / total` status in place of the old page indicator.
- Add unit tests covering prefetch, append, end-of-list, and reset-on-reload behavior.

Local "This PC" packages were already unpaged and are unchanged.

## Motivation and Context
Previously remote package results used First/Back/Next/Last paging, so users had to step through pages to find software.

Issue #1048 originally asked for a configurable page size. Discussion on that issue preferred dropping pagination entirely in favor of infinite scrolling, which matches how most app stores and package manager UIs work.

This change replaces page navigation with a continuous list that loads more packages as the user scrolls, prefetching ahead so later batches are ready before the bottom of the list is reached.

Related: #1090

## Testing
1. Unit tests: `RemoteSourceViewModelTests` (7 passing), covering prefetch of two additional pages, append without clearing, short last batch / no further fetch, and reset after append.
2. Manual GUI testing against community and other remote sources: scroll past the first loaded batch and confirm more packages appear without using pager buttons.
3. Manual checks that search, sort, prerelease, all-versions, and refresh reset the list and start over from the top.
4. Manual checks in both tile and list views, including that scrolling remains usable while later batches load in the background.
5. Manual check of a small source that fits on one screen (no unnecessary extra fetch loop).

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #1048